### PR TITLE
feat(limit-orders): index OrderPreSigned and LimitOrderFeeChange (#189)

### DIFF
--- a/abis/LimitOrderEngine.json
+++ b/abis/LimitOrderEngine.json
@@ -1,2774 +1,3295 @@
 {
-   "abi":[
-      {
-         "type":"constructor",
-         "inputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"advanceNonce",
-         "inputs":[
+  "abi": [
+    {
+      "type": "constructor",
+      "inputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "MAX_LIMIT_ORDER_FEE",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "advanceNonce",
+      "inputs": [
+        {
+          "name": "amount",
+          "type": "uint8",
+          "internalType": "uint8"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "authority",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "cancelBatch",
+      "inputs": [
+        {
+          "name": "orders",
+          "type": "tuple[]",
+          "internalType": "struct ILimitOrderEngine.Order[]",
+          "components": [
             {
-               "name":"amount",
-               "type":"uint8",
-               "internalType":"uint8"
-            }
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"authority",
-         "inputs":[
-            
-         ],
-         "outputs":[
-            {
-               "name":"",
-               "type":"address",
-               "internalType":"address"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"cancelBatch",
-         "inputs":[
-            {
-               "name":"orders",
-               "type":"tuple[]",
-               "internalType":"struct ILimitOrderEngine.Order[]",
-               "components":[
-                  {
-                     "name":"salt",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"expiry",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"nonce",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"orderType",
-                     "type":"uint8",
-                     "internalType":"enum ILimitOrderEngine.OrderType"
-                  },
-                  {
-                     "name":"PT",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"maker",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"receiver",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"makingAmount",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"impliedRate",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"permit",
-                     "type":"bytes",
-                     "internalType":"bytes"
-                  }
-               ]
-            }
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"cancelSingle",
-         "inputs":[
-            {
-               "name":"order",
-               "type":"tuple",
-               "internalType":"struct ILimitOrderEngine.Order",
-               "components":[
-                  {
-                     "name":"salt",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"expiry",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"nonce",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"orderType",
-                     "type":"uint8",
-                     "internalType":"enum ILimitOrderEngine.OrderType"
-                  },
-                  {
-                     "name":"PT",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"maker",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"receiver",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"makingAmount",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"impliedRate",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"permit",
-                     "type":"bytes",
-                     "internalType":"bytes"
-                  }
-               ]
-            }
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"eip712Domain",
-         "inputs":[
-            
-         ],
-         "outputs":[
-            {
-               "name":"fields",
-               "type":"bytes1",
-               "internalType":"bytes1"
+              "name": "salt",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"name",
-               "type":"string",
-               "internalType":"string"
+              "name": "expiry",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"version",
-               "type":"string",
-               "internalType":"string"
+              "name": "nonce",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"chainId",
-               "type":"uint256",
-               "internalType":"uint256"
+              "name": "orderType",
+              "type": "uint8",
+              "internalType": "enum ILimitOrderEngine.OrderType"
             },
             {
-               "name":"verifyingContract",
-               "type":"address",
-               "internalType":"address"
+              "name": "pt",
+              "type": "address",
+              "internalType": "address"
             },
             {
-               "name":"salt",
-               "type":"bytes32",
-               "internalType":"bytes32"
+              "name": "maker",
+              "type": "address",
+              "internalType": "address"
             },
             {
-               "name":"extensions",
-               "type":"uint256[]",
-               "internalType":"uint256[]"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"feeRecipient",
-         "inputs":[
-            
-         ],
-         "outputs":[
-            {
-               "name":"",
-               "type":"address",
-               "internalType":"address"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"hashOrder",
-         "inputs":[
-            {
-               "name":"order",
-               "type":"tuple",
-               "internalType":"struct ILimitOrderEngine.Order",
-               "components":[
-                  {
-                     "name":"salt",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"expiry",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"nonce",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"orderType",
-                     "type":"uint8",
-                     "internalType":"enum ILimitOrderEngine.OrderType"
-                  },
-                  {
-                     "name":"PT",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"maker",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"receiver",
-                     "type":"address",
-                     "internalType":"address"
-                  },
-                  {
-                     "name":"makingAmount",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"impliedRate",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"permit",
-                     "type":"bytes",
-                     "internalType":"bytes"
-                  }
-               ]
-            }
-         ],
-         "outputs":[
-            {
-               "name":"",
-               "type":"bytes32",
-               "internalType":"bytes32"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"increaseNonce",
-         "inputs":[
-            
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"initialize",
-         "inputs":[
-            {
-               "name":"_feeRecipient",
-               "type":"address",
-               "internalType":"address"
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
             },
             {
-               "name":"_router",
-               "type":"address",
-               "internalType":"address"
+              "name": "makingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"_initialAuthority",
-               "type":"address",
-               "internalType":"address"
+              "name": "impliedRate",
+              "type": "uint256",
+              "internalType": "uint256"
             }
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"isConsumingScheduledOp",
-         "inputs":[
-            
-         ],
-         "outputs":[
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "cancelSingle",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct ILimitOrderEngine.Order",
+          "components": [
             {
-               "name":"",
-               "type":"bytes4",
-               "internalType":"bytes4"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"nonce",
-         "inputs":[
-            {
-               "name":"",
-               "type":"address",
-               "internalType":"address"
-            }
-         ],
-         "outputs":[
-            {
-               "name":"",
-               "type":"uint256",
-               "internalType":"uint256"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"nonceEquals",
-         "inputs":[
-            {
-               "name":"makerAddress",
-               "type":"address",
-               "internalType":"address"
+              "name": "salt",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"makerNonce",
-               "type":"uint256",
-               "internalType":"uint256"
-            }
-         ],
-         "outputs":[
-            {
-               "name":"",
-               "type":"bool",
-               "internalType":"bool"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"orderStatuses",
-         "inputs":[
-            {
-               "name":"orderHashes",
-               "type":"bytes32[]",
-               "internalType":"bytes32[]"
-            }
-         ],
-         "outputs":[
-            {
-               "name":"remainings",
-               "type":"uint256[]",
-               "internalType":"uint256[]"
+              "name": "expiry",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"filledAmounts",
-               "type":"uint256[]",
-               "internalType":"uint256[]"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"orderStatusesRaw",
-         "inputs":[
-            {
-               "name":"orderHashes",
-               "type":"bytes32[]",
-               "internalType":"bytes32[]"
-            }
-         ],
-         "outputs":[
-            {
-               "name":"remainingsRaw",
-               "type":"uint256[]",
-               "internalType":"uint256[]"
+              "name": "nonce",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"filledAmounts",
-               "type":"uint256[]",
-               "internalType":"uint256[]"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"pause",
-         "inputs":[
-            
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"paused",
-         "inputs":[
-            
-         ],
-         "outputs":[
-            {
-               "name":"",
-               "type":"bool",
-               "internalType":"bool"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"router",
-         "inputs":[
-            
-         ],
-         "outputs":[
-            {
-               "name":"",
-               "type":"address",
-               "internalType":"address"
-            }
-         ],
-         "stateMutability":"view"
-      },
-      {
-         "type":"function",
-         "name":"setAuthority",
-         "inputs":[
-            {
-               "name":"newAuthority",
-               "type":"address",
-               "internalType":"address"
-            }
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"setFeeRecipient",
-         "inputs":[
-            {
-               "name":"newFeeRecipient",
-               "type":"address",
-               "internalType":"address"
-            }
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"setRouter",
-         "inputs":[
-            {
-               "name":"newRouter",
-               "type":"address",
-               "internalType":"address"
-            }
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"transferPostValidation",
-         "inputs":[
-            {
-               "name":"receiver",
-               "type":"address",
-               "internalType":"address"
+              "name": "orderType",
+              "type": "uint8",
+              "internalType": "enum ILimitOrderEngine.OrderType"
             },
             {
-               "name":"params",
-               "type":"tuple[]",
-               "internalType":"struct ILimitOrderEngine.FillOrderParams[]",
-               "components":[
-                  {
-                     "name":"order",
-                     "type":"tuple",
-                     "internalType":"struct ILimitOrderEngine.Order",
-                     "components":[
-                        {
-                           "name":"salt",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"expiry",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"nonce",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"orderType",
-                           "type":"uint8",
-                           "internalType":"enum ILimitOrderEngine.OrderType"
-                        },
-                        {
-                           "name":"PT",
-                           "type":"address",
-                           "internalType":"address"
-                        },
-                        {
-                           "name":"maker",
-                           "type":"address",
-                           "internalType":"address"
-                        },
-                        {
-                           "name":"receiver",
-                           "type":"address",
-                           "internalType":"address"
-                        },
-                        {
-                           "name":"makingAmount",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"impliedRate",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"permit",
-                           "type":"bytes",
-                           "internalType":"bytes"
-                        }
-                     ]
-                  },
-                  {
-                     "name":"signature",
-                     "type":"bytes",
-                     "internalType":"bytes"
-                  },
-                  {
-                     "name":"makingAmount",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"maxTaking",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  }
-               ]
+              "name": "pt",
+              "type": "address",
+              "internalType": "address"
             },
             {
-               "name":"validatedResults",
-               "type":"tuple[]",
-               "internalType":"struct ILimitOrderEngine.OrderResult[]",
-               "components":[
-                  {
-                     "name":"actualTaking",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"actualMaking",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  }
-               ]
+              "name": "maker",
+              "type": "address",
+              "internalType": "address"
             },
             {
-               "name":"takerToken",
-               "type":"address",
-               "internalType":"contract IERC20"
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
             },
             {
-               "name":"totalFees",
-               "type":"uint256",
-               "internalType":"uint256"
-            }
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"unpause",
-         "inputs":[
-            
-         ],
-         "outputs":[
-            
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"function",
-         "name":"validateOrdersAndUpdateStatus",
-         "inputs":[
-            {
-               "name":"params",
-               "type":"tuple[]",
-               "internalType":"struct ILimitOrderEngine.FillOrderParams[]",
-               "components":[
-                  {
-                     "name":"order",
-                     "type":"tuple",
-                     "internalType":"struct ILimitOrderEngine.Order",
-                     "components":[
-                        {
-                           "name":"salt",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"expiry",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"nonce",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"orderType",
-                           "type":"uint8",
-                           "internalType":"enum ILimitOrderEngine.OrderType"
-                        },
-                        {
-                           "name":"PT",
-                           "type":"address",
-                           "internalType":"address"
-                        },
-                        {
-                           "name":"maker",
-                           "type":"address",
-                           "internalType":"address"
-                        },
-                        {
-                           "name":"receiver",
-                           "type":"address",
-                           "internalType":"address"
-                        },
-                        {
-                           "name":"makingAmount",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"impliedRate",
-                           "type":"uint256",
-                           "internalType":"uint256"
-                        },
-                        {
-                           "name":"permit",
-                           "type":"bytes",
-                           "internalType":"bytes"
-                        }
-                     ]
-                  },
-                  {
-                     "name":"signature",
-                     "type":"bytes",
-                     "internalType":"bytes"
-                  },
-                  {
-                     "name":"makingAmount",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"maxTaking",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  }
-               ]
-            }
-         ],
-         "outputs":[
-            {
-               "name":"validatedResults",
-               "type":"tuple[]",
-               "internalType":"struct ILimitOrderEngine.OrderResult[]",
-               "components":[
-                  {
-                     "name":"actualTaking",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  },
-                  {
-                     "name":"actualMaking",
-                     "type":"uint256",
-                     "internalType":"uint256"
-                  }
-               ]
+              "name": "makingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"takerToken",
-               "type":"address",
-               "internalType":"address"
+              "name": "impliedRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "eip712Domain",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "fields",
+          "type": "bytes1",
+          "internalType": "bytes1"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "internalType": "string"
+        },
+        {
+          "name": "version",
+          "type": "string",
+          "internalType": "string"
+        },
+        {
+          "name": "chainId",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "verifyingContract",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "salt",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "extensions",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "feeRecipient",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "fillOrders",
+      "inputs": [
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "params",
+          "type": "tuple[]",
+          "internalType": "struct ILimitOrderEngine.FillOrderParams[]",
+          "components": [
+            {
+              "name": "order",
+              "type": "tuple",
+              "internalType": "struct ILimitOrderEngine.Order",
+              "components": [
+                {
+                  "name": "salt",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "expiry",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "orderType",
+                  "type": "uint8",
+                  "internalType": "enum ILimitOrderEngine.OrderType"
+                },
+                {
+                  "name": "pt",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "maker",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "makingAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "impliedRate",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
             },
             {
-               "name":"totalTaking",
-               "type":"uint256",
-               "internalType":"uint256"
+              "name": "signature",
+              "type": "bytes",
+              "internalType": "bytes"
             },
             {
-               "name":"totalFees",
-               "type":"uint256",
-               "internalType":"uint256"
-            }
-         ],
-         "stateMutability":"nonpayable"
-      },
-      {
-         "type":"event",
-         "name":"AuthorityUpdated",
-         "inputs":[
-            {
-               "name":"authority",
-               "type":"address",
-               "indexed":false,
-               "internalType":"address"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"EIP712DomainChanged",
-         "inputs":[
-            
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"FeeRecipientUpdated",
-         "inputs":[
-            {
-               "name":"newFeeRecipient",
-               "type":"address",
-               "indexed":true,
-               "internalType":"address"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"Initialized",
-         "inputs":[
-            {
-               "name":"version",
-               "type":"uint64",
-               "indexed":false,
-               "internalType":"uint64"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"NonceIncreased",
-         "inputs":[
-            {
-               "name":"maker",
-               "type":"address",
-               "indexed":true,
-               "internalType":"address"
+              "name": "makingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"oldNonce",
-               "type":"uint256",
-               "indexed":false,
-               "internalType":"uint256"
+              "name": "maxTaking",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "data",
+          "type": "bytes",
+          "internalType": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getLimitOrderFee",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "hashOrder",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct ILimitOrderEngine.Order",
+          "components": [
+            {
+              "name": "salt",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"newNonce",
-               "type":"uint256",
-               "indexed":false,
-               "internalType":"uint256"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"OrderCanceled",
-         "inputs":[
-            {
-               "name":"maker",
-               "type":"address",
-               "indexed":false,
-               "internalType":"address"
+              "name": "expiry",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"orderHash",
-               "type":"bytes32",
-               "indexed":false,
-               "internalType":"bytes32"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"OrderFilled",
-         "inputs":[
-            {
-               "name":"orderHash",
-               "type":"bytes32",
-               "indexed":false,
-               "internalType":"bytes32"
+              "name": "nonce",
+              "type": "uint256",
+              "internalType": "uint256"
             },
             {
-               "name":"actualMaking",
-               "type":"uint256",
-               "indexed":false,
-               "internalType":"uint256"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"Paused",
-         "inputs":[
-            {
-               "name":"account",
-               "type":"address",
-               "indexed":false,
-               "internalType":"address"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"RouterUpdated",
-         "inputs":[
-            {
-               "name":"newRouter",
-               "type":"address",
-               "indexed":true,
-               "internalType":"address"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"event",
-         "name":"Unpaused",
-         "inputs":[
-            {
-               "name":"account",
-               "type":"address",
-               "indexed":false,
-               "internalType":"address"
-            }
-         ],
-         "anonymous":false
-      },
-      {
-         "type":"error",
-         "name":"AccessManagedInvalidAuthority",
-         "inputs":[
-            {
-               "name":"authority",
-               "type":"address",
-               "internalType":"address"
-            }
-         ]
-      },
-      {
-         "type":"error",
-         "name":"AccessManagedRequiredDelay",
-         "inputs":[
-            {
-               "name":"caller",
-               "type":"address",
-               "internalType":"address"
+              "name": "orderType",
+              "type": "uint8",
+              "internalType": "enum ILimitOrderEngine.OrderType"
             },
             {
-               "name":"delay",
-               "type":"uint32",
-               "internalType":"uint32"
-            }
-         ]
-      },
-      {
-         "type":"error",
-         "name":"AccessManagedUnauthorized",
-         "inputs":[
-            {
-               "name":"caller",
-               "type":"address",
-               "internalType":"address"
-            }
-         ]
-      },
-      {
-         "type":"error",
-         "name":"AlreadyFilled",
-         "inputs":[
-            {
-               "name":"orderId",
-               "type":"bytes32",
-               "internalType":"bytes32"
-            }
-         ]
-      },
-      {
-         "type":"error",
-         "name":"EnforcedPause",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"ExpectedPause",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"IncompatibleOrderBatch",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"InvalidInitialization",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"InvalidOrderType",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"MaxTakingExceeded",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"NoValidOrder",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"NotInitializing",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"NotMaker",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"NotRouter",
-         "inputs":[
-            
-         ]
-      },
-      {
-         "type":"error",
-         "name":"OrderNotExisting",
-         "inputs":[
-            {
-               "name":"orderId",
-               "type":"bytes32",
-               "internalType":"bytes32"
-            }
-         ]
-      },
-      {
-         "type":"error",
-         "name":"SafeCastOverflowedUintDowncast",
-         "inputs":[
-            {
-               "name":"bits",
-               "type":"uint8",
-               "internalType":"uint8"
+              "name": "pt",
+              "type": "address",
+              "internalType": "address"
             },
             {
-               "name":"value",
-               "type":"uint256",
-               "internalType":"uint256"
+              "name": "maker",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "makingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "impliedRate",
+              "type": "uint256",
+              "internalType": "uint256"
             }
-         ]
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "increaseNonce",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "inputs": [
+        {
+          "name": "_registry",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "_router",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "_initialAuthority",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "isConsumingScheduledOp",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes4",
+          "internalType": "bytes4"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "nonce",
+      "inputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "nonceEquals",
+      "inputs": [
+        {
+          "name": "makerAddress",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "makerNonce",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "orderStatuses",
+      "inputs": [
+        {
+          "name": "orderHashes",
+          "type": "bytes32[]",
+          "internalType": "bytes32[]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "remainings",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        },
+        {
+          "name": "filledAmounts",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "orderStatusesRaw",
+      "inputs": [
+        {
+          "name": "orderHashes",
+          "type": "bytes32[]",
+          "internalType": "bytes32[]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "remainingsRaw",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        },
+        {
+          "name": "filledAmounts",
+          "type": "uint256[]",
+          "internalType": "uint256[]"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "pause",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "paused",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool",
+          "internalType": "bool"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "preSignBatch",
+      "inputs": [
+        {
+          "name": "orders",
+          "type": "tuple[]",
+          "internalType": "struct ILimitOrderEngine.Order[]",
+          "components": [
+            {
+              "name": "salt",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "expiry",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "nonce",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "orderType",
+              "type": "uint8",
+              "internalType": "enum ILimitOrderEngine.OrderType"
+            },
+            {
+              "name": "pt",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "maker",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "makingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "impliedRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "preSignSingle",
+      "inputs": [
+        {
+          "name": "order",
+          "type": "tuple",
+          "internalType": "struct ILimitOrderEngine.Order",
+          "components": [
+            {
+              "name": "salt",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "expiry",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "nonce",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "orderType",
+              "type": "uint8",
+              "internalType": "enum ILimitOrderEngine.OrderType"
+            },
+            {
+              "name": "pt",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "maker",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "receiver",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "makingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "impliedRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "registry",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "router",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "setAuthority",
+      "inputs": [
+        {
+          "name": "newAuthority",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setLimitOrderFee",
+      "inputs": [
+        {
+          "name": "_limitOrderFee",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "setRouter",
+      "inputs": [
+        {
+          "name": "newRouter",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "transferPostValidation",
+      "inputs": [
+        {
+          "name": "receiver",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "params",
+          "type": "tuple[]",
+          "internalType": "struct ILimitOrderEngine.FillOrderParams[]",
+          "components": [
+            {
+              "name": "order",
+              "type": "tuple",
+              "internalType": "struct ILimitOrderEngine.Order",
+              "components": [
+                {
+                  "name": "salt",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "expiry",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "orderType",
+                  "type": "uint8",
+                  "internalType": "enum ILimitOrderEngine.OrderType"
+                },
+                {
+                  "name": "pt",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "maker",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "makingAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "impliedRate",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "signature",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "makingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxTaking",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "validatedResults",
+          "type": "tuple[]",
+          "internalType": "struct ILimitOrderEngine.OrderResult[]",
+          "components": [
+            {
+              "name": "actualTaking",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "actualMaking",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "takerToken",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "totalTaking",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "totalFees",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "unpause",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "validateOrdersAndUpdateStatus",
+      "inputs": [
+        {
+          "name": "params",
+          "type": "tuple[]",
+          "internalType": "struct ILimitOrderEngine.FillOrderParams[]",
+          "components": [
+            {
+              "name": "order",
+              "type": "tuple",
+              "internalType": "struct ILimitOrderEngine.Order",
+              "components": [
+                {
+                  "name": "salt",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "expiry",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "nonce",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "orderType",
+                  "type": "uint8",
+                  "internalType": "enum ILimitOrderEngine.OrderType"
+                },
+                {
+                  "name": "pt",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "maker",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "receiver",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "makingAmount",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "impliedRate",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            },
+            {
+              "name": "signature",
+              "type": "bytes",
+              "internalType": "bytes"
+            },
+            {
+              "name": "makingAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "maxTaking",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "outputs": [
+        {
+          "name": "validatedResults",
+          "type": "tuple[]",
+          "internalType": "struct ILimitOrderEngine.OrderResult[]",
+          "components": [
+            {
+              "name": "actualTaking",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "actualMaking",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        },
+        {
+          "name": "takerToken",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "totalTaking",
+          "type": "uint256",
+          "internalType": "uint256"
+        },
+        {
+          "name": "totalFees",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "AuthorityUpdated",
+      "inputs": [
+        {
+          "name": "authority",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "EIP712DomainChanged",
+      "inputs": [],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "FeeRecipientUpdated",
+      "inputs": [
+        {
+          "name": "newFeeRecipient",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Initialized",
+      "inputs": [
+        {
+          "name": "version",
+          "type": "uint64",
+          "indexed": false,
+          "internalType": "uint64"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "LimitOrderFeeChange",
+      "inputs": [
+        {
+          "name": "previousLimitOrderFee",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "newLimitOrderFee",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "NonceIncreased",
+      "inputs": [
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "oldNonce",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        },
+        {
+          "name": "newNonce",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OrderCanceled",
+      "inputs": [
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        },
+        {
+          "name": "orderHash",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OrderFilled",
+      "inputs": [
+        {
+          "name": "orderHash",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "actualMaking",
+          "type": "uint256",
+          "indexed": false,
+          "internalType": "uint256"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "OrderPreSigned",
+      "inputs": [
+        {
+          "name": "orderHash",
+          "type": "bytes32",
+          "indexed": true,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "maker",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Paused",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "RouterUpdated",
+      "inputs": [
+        {
+          "name": "newRouter",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "Unpaused",
+      "inputs": [
+        {
+          "name": "account",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "error",
+      "name": "AccessManagedInvalidAuthority",
+      "inputs": [
+        {
+          "name": "authority",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "AccessManagedRequiredDelay",
+      "inputs": [
+        {
+          "name": "caller",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "delay",
+          "type": "uint32",
+          "internalType": "uint32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "AccessManagedUnauthorized",
+      "inputs": [
+        {
+          "name": "caller",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "AlreadyFilled",
+      "inputs": [
+        {
+          "name": "orderId",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "EnforcedPause",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "ExpectedPause",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "FeeGreaterThanMaxValue",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "IncompatibleOrderBatch",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InsufficientFunds",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidBatchParams",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidInitialization",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidOrderForPreSign",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "InvalidOrderType",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "MaxTakingExceeded",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NegativeImpliedRate",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NoValidOrder",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NotInitializing",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NotMaker",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "NotRouter",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "OrderAlreadyRegistered",
+      "inputs": [
+        {
+          "name": "orderHash",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "OrderNotExisting",
+      "inputs": [
+        {
+          "name": "orderId",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "ReentrancyGuardReentrantCall",
+      "inputs": []
+    },
+    {
+      "type": "error",
+      "name": "SafeCastOverflowedUintDowncast",
+      "inputs": [
+        {
+          "name": "bits",
+          "type": "uint8",
+          "internalType": "uint8"
+        },
+        {
+          "name": "value",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ]
+    },
+    {
+      "type": "error",
+      "name": "SafeERC20FailedOperation",
+      "inputs": [
+        {
+          "name": "token",
+          "type": "address",
+          "internalType": "address"
+        }
+      ]
+    }
+  ],
+  "bytecode": {
+    "object": "0x6080604052348015600e575f5ffd5b5060156019565b60c9565b7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00805468010000000000000000900460ff161560685760405163f92ee8a960e01b815260040160405180910390fd5b80546001600160401b039081161460c65780546001600160401b0319166001600160401b0390811782556040519081527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a15b50565b614ab7806100d65f395ff3fe608060405234801561000f575f5ffd5b50600436106101c6575f3560e01c806371c707eb116100fe5780638ed9b04b1161009e578063c0d786551161006e578063c0d78655146103e7578063c53a0292146103fa578063cf6fc6e314610402578063f887ea401461042e575f5ffd5b80638ed9b04b146103985780638fb36037146103ab578063bf7e214f146103cc578063c0c53b8b146103d4575f5ffd5b80637b103999116100d95780637b1039991461033f5780638456cb591461035257806384b0196e1461035a5780638b96e39e14610375575f5ffd5b806371c707eb1461030657806372c244a8146103195780637a9e5e4b1461032c575f5ffd5b8063469048401161016957806364278cf61161014457806364278cf6146102ae5780636bec6723146102c15780636ee83986146102d457806370ae92d2146102e7575f5ffd5b806346904840146102585780634cb4069e146102785780635c975abb1461028b575f5ffd5b80633b733c66116101a45780633b733c66146102195780633e076174146102285780633f4ba83a1461023d578063458edd7414610245575f5ffd5b80630c0b8c9c146101ca57806334b08c05146101f457806335ee3ffc14610206575b5f5ffd5b6101dd6101d8366004613d48565b610441565b6040516101eb929190613dc0565b60405180910390f35b6067545b6040519081526020016101eb565b6101dd610214366004613d48565b6104fb565b6101f8670de0b6b3a764000081565b61023b610236366004613de4565b61063b565b005b61023b61067b565b61023b610253366004613e54565b610691565b610260610704565b6040516001600160a01b0390911681526020016101eb565b61023b610286366004614157565b610774565b5f516020614a625f395f51905f525460ff165b60405190151581526020016101eb565b6101f86102bc3660046141cb565b61081d565b61023b6102cf3660046141e6565b610875565b61023b6102e2366004613de4565b6109b8565b6101f86102f5366004614200565b5f6020819052908152604090205481565b61023b6103143660046141e6565b6109eb565b61023b610327366004614229565b610ad0565b61023b61033a366004614200565b610b4a565b606654610260906001600160a01b031681565b61023b610bd0565b610362610be1565b6040516101eb9796959493929190614272565b610388610383366004613d48565b610c8a565b6040516101eb94939291906142d3565b61023b6103a6366004614340565b610cc1565b6103b3610d18565b6040516001600160e01b031990911681526020016101eb565b610260610d4e565b61023b6103e2366004614453565b610d69565b61023b6103f5366004614200565b610ef9565b61023b610f4b565b61029e61041036600461449b565b6001600160a01b03919091165f908152602081905260409020541490565b606554610260906001600160a01b031681565b60608061044e84846104fb565b90925090505f5b82518110156104f3575f6001600160801b031683828151811061047a5761047a6144c5565b6020026020010151036104c557848482818110610499576104996144c5565b905060200201356040516384a19ff760e01b81526004016104bc91815260200190565b60405180910390fd5b60018382815181106104d9576104d96144c5565b602090810291909101018051919091039052600101610455565b509250929050565b60608082806001600160401b0381111561051757610517613e8a565b604051908082528060200260200182016040528015610540578160200160208202803683370190505b509250806001600160401b0381111561055b5761055b613e8a565b604051908082528060200260200182016040528015610584578160200160208202803683370190505b5091505f5b81811015610632575f60685f8888858181106105a7576105a76144c5565b602090810292909201358352508181019290925260409081015f208151808301909252546001600160801b03808216808452600160801b9092041692820183905287519193509190879085908110610601576106016144c5565b6020026020010186858151811061061a5761061a6144c5565b60209081029190910101919091525250600101610589565b50509250929050565b610643610f55565b5f5b818110156106765761066e838383818110610662576106626144c5565b90506101200201610875565b600101610645565b505050565b610687335b5f36610f85565b61068f61107b565b565b61069a33610680565b670de0b6b3a76400008111156106c3576040516315118d7560e11b815260040160405180910390fd5b60675460408051918252602082018390527fb56ebecadafe35f0143935e7910bba2164278066a327a34cc9d11a8a7fa172b4910160405180910390a1606755565b606654604080516312fde4b760e01b815290515f926001600160a01b0316916312fde4b79160048083019260209291908290030181865afa15801561074b573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061076f91906144d9565b905090565b61077c6110da565b610784610f55565b5f8180602001905181019061079991906144d9565b90505f5f5f5f6107a887611105565b93509350935093506107ba87856114dc565b610805875f815181106107cf576107cf6144c5565b60200260200101515f015160800151885f815181106107f0576107f06144c5565b60200260200101515f0151606001518761159b565b6108138888868686866119a5565b5050505050505050565b5f61086f7f1c3eac1da0ab9cb83b042d46ed8a1047556ac9c02e1cb540a4971ee333c7cc4283604051602001610854929190614508565b60405160208183030381529060405280519060200120611aec565b92915050565b61087d610f55565b3361088e60c0830160a08401614200565b6001600160a01b0316146108b55760405163b331e42160e01b815260040160405180910390fd5b60e081013515806108da57506108d86108d3368390038301836141cb565b611b18565b155b156108f85760405163756e10b960e11b815260040160405180910390fd5b5f61090b6102bc368490038401846141cb565b5f818152606860205260409020549091506001600160801b0316156109465760405163aa61587160e01b8152600481018290526024016104bc565b61095d61095860e084013560016145cd565b611bec565b5f8281526068602052604080822080546001600160801b0319166001600160801b0394909416939093179092559051339183917f9645e207a42485247ea4cb002af5c3aa3232570ae805ee4ca3eee263a68895ee9190a35050565b5f5b81811015610676576109e38383838181106109d7576109d76144c5565b905061012002016109eb565b6001016109ba565b336109fc60c0830160a08401614200565b6001600160a01b031614610a235760405163b331e42160e01b815260040160405180910390fd5b5f610a366102bc368490038401846141cb565b5f818152606860205260409020549091506001600160801b03165f1901610a735760405163cee8144360e01b8152600481018290526024016104bc565b5f8181526068602090815260409182902080546001600160801b031916600117905581513381529081018390527f35ab4a1a0e9bec7fd7ae164679b9cc00e6568e4db238d8055a75b1862f62ec2e91015b60405180910390a15050565b335f90815260208190526040812054610aed9060ff8416906145cd565b335f8181526020819052604090208290559091507fdc0537f71d06d3708f52baf4ddf6918b25f1a145ba08873de27485682b35cac1610b2f60ff8516846145e0565b60408051918252602082018590520160405180910390a25050565b33610b53610d4e565b6001600160a01b0316816001600160a01b031614610b8e5760405162d1953b60e31b81526001600160a01b03821660048201526024016104bc565b816001600160a01b03163b5f03610bc3576040516361798f2f60e11b81526001600160a01b03831660048201526024016104bc565b610bcc82611c23565b5050565b610bd933610680565b61068f611c7c565b5f60608082808083815f516020614a425f395f51905f528054909150158015610c0c57506001810154155b610c505760405162461bcd60e51b81526020600482015260156024820152741152540dcc4c8e88155b9a5b9a5d1a585b1a5e9959605a1b60448201526064016104bc565b610c58611cc4565b610c60611d84565b604080515f80825260208201909252600f60f81b9c939b5091995046985030975095509350915050565b60605f5f5f610c976110da565b610c9f610f55565b610cb1610cac86886145f3565b611105565b9299919850965090945092505050565b610cc96110da565b610cd1610f55565b610cd9611dc2565b610ce78686868686866119a5565b610d1060017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f0055565b505050505050565b5f516020614a225f395f51905f5280545f9190600160a01b900460ff16610d3f575f610d48565b638fb3603760e01b5b91505090565b5f516020614a225f395f51905f52546001600160a01b031690565b5f610d72611e32565b805490915060ff600160401b82041615906001600160401b03165f81158015610d985750825b90505f826001600160401b03166001148015610db35750303b155b905081158015610dc1575080155b15610ddf5760405163f92ee8a960e01b815260040160405180910390fd5b845467ffffffffffffffff191660011785558315610e0957845460ff60401b1916600160401b1785555b610e1286611e5a565b610e6a6040518060400160405280601c81526020017f53706563747261204c696d6974204f726465722050726f746f636f6c00000000815250604051806040016040528060018152602001603160f81b815250611e6e565b610e72611e80565b610e7a611e88565b606680546001600160a01b03808b166001600160a01b03199283161790925560658054928a1692909116919091179055831561081357845460ff60401b19168555604051600181527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a15050505050505050565b610f0233610680565b606580546001600160a01b0319166001600160a01b0383169081179091556040517f7aed1d3e8155a07ccf395e44ea3109a0e2d6c9b29bbbe9f142d9790596f4dc80905f90a250565b61068f6001610ad0565b5f516020614a625f395f51905f525460ff161561068f5760405163d93c066560e01b815260040160405180910390fd5b5f516020614a225f395f51905f525f80610fbd610fa0610d4e565b8730610faf60045f8a8c6145ff565b610fb891614626565b611e98565b9150915081610d105763ffffffff81161561105857825460ff60a01b1916600160a01b178355610feb610d4e565b6001600160a01b03166394c7d7ee8787876040518463ffffffff1660e01b815260040161101a9392919061465e565b5f604051808303815f87803b158015611031575f5ffd5b505af1158015611043573d5f5f3e3d5ffd5b5050845460ff60a01b1916855550610d109050565b60405162d1953b60e31b81526001600160a01b03871660048201526024016104bc565b611083611f2a565b5f516020614a625f395f51905f52805460ff191681557f5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa335b6040516001600160a01b03909116815260200160405180910390a150565b6065546001600160a01b0316331461068f57604051639165520160e01b815260040160405180910390fd5b60605f5f5f5f5f865f8151811061111e5761111e6144c5565b60200260200101515f015160600151905086516001600160401b0381111561114857611148613e8a565b60405190808252806020026020018201604052801561118c57816020015b604080518082019091525f80825260208201528152602001906001900390816111665790505b5095505f5b87518110156114b1575f8882815181106111ad576111ad6144c5565b60200260200101515f015190506111e5895f815181106111cf576111cf6144c5565b60200260200101515f0151608001518483611f59565b6112055760405160016205f80f60e41b0319815260040160405180910390fd5b61120e81611b18565b6112235761121b8461469d565b9350506114a9565b5f61122d8261081d565b5f818152606860205260408120549192506001600160801b0390911615801591906112a8575f838152606860205260409020546001600160801b031660011480156112875761127b8861469d565b975050505050506114a9565b50505f828152606860205260409020546001600160801b03165f19016112e4565b5f6112cc8d87815181106112be576112be6144c5565b602002602001015185611fae565b9050806112dc5761127b8861469d565b505060e08301515b5f61130c828e88815181106112fb576112fb6144c5565b602002602001015160400151611fc5565b90508082039150604051806040016040528061132a84600101611bec565b6001600160801b0390811682525f8781526068602090815260409091205492019161135f91600160801b909104168401611bec565b6001600160801b039081169091525f8681526068602090815260408083208551958301518516600160801b0295909416949094179092558251808401909352808352908201526113af8683611fd4565b602083015281528d518e90889081106113ca576113ca6144c5565b6020026020010151606001518160200151825f01516113e991906145cd565b11156114085760405163a28213a360e01b815260040160405180910390fd5b6020810151815161141991906145cd565b611423908c6145cd565b9a5080602001518a61143591906145cd565b99506040518060400160405280825f01518152602001838152508d8881518110611461576114616144c5565b60209081029190910101526001600160a01b038c166114a25761149f8e888151811061148f5761148f6144c5565b60200260200101515f015161205a565b9b505b5050505050505b600101611191565b50865182036114d357604051639bc0260d60e01b815260040160405180910390fd5b50509193509193565b5f5b8151811015610676578181815181106114f9576114f96144c5565b6020026020010151602001515f0315611593575f611532848381518110611522576115226144c5565b60200260200101515f01516121df565b9050611591848381518110611549576115496144c5565b60200260200101515f015160a001513085858151811061156b5761156b6144c5565b602002602001015160200151846001600160a01b031661233e909392919063ffffffff16565b505b6001016114de565b5f8390505f816001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156115dc573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061160091906144d9565b90505f826001600160a01b03166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa15801561163f573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061166391906144d9565b9050816001600160a01b0316846001600160a01b03161480156116b257506001856004811115611695576116956144f4565b14806116b2575060038560048111156116b0576116b06144f4565b145b156117b8576040516370a0823160e01b81523060048201525f906001600160a01b038416906370a0823190602401602060405180830381865afa1580156116fb573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061171f91906146b5565b905080156117b25761173b6001600160a01b03841688836123ab565b604051632eb7f01d60e21b815260048101829052306024820181905260448201526001600160a01b0385169063badfc074906064016020604051808303815f875af115801561178c573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906117b091906146b5565b505b50610d10565b856001600160a01b0316846001600160a01b03161480156117ea575060048560048111156117e8576117e86144f4565b145b806118225750806001600160a01b0316846001600160a01b031614801561182257506002856004811115611820576118206144f4565b145b15610d10576040516370a0823160e01b81523060048201525f906001600160a01b038816906370a0823190602401602060405180830381865afa15801561186b573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061188f91906146b5565b6040516370a0823160e01b81523060048201529091505f906001600160a01b038416906370a0823190602401602060405180830381865afa1580156118d6573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906118fa91906146b5565b90505f6119078383611fc5565b9050801561199a576119236001600160a01b0385168a836123ab565b60405163b2afd5a360e01b815260048101829052306024820181905260448201526001600160a01b0387169063b2afd5a3906064016020604051808303815f875af1158015611974573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061199891906146b5565b505b505050505050505050565b845115806119b557508351855114155b156119d3576040516305373a5b60e41b815260040160405180910390fd5b6001600160a01b03861615806119f057506001600160a01b038316155b15611a0e576040516305373a5b60e41b815260040160405180910390fd5b6040516370a0823160e01b815230600482015282906001600160a01b038516906370a0823190602401602060405180830381865afa158015611a52573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611a7691906146b5565b1015611a955760405163356680b760e01b815260040160405180910390fd5b611aa0858585612432565b8015611ac257611ac2611ab1610704565b6001600160a01b0385169083612548565b610d1086865f81518110611ad857611ad86144c5565b60200260200101515f015160800151612579565b5f61086f611af86127d2565b8360405161190160f01b8152600281019290925260228201526042902090565b5f42826020015111611b2b57505f919050565b5f82608001516001600160a01b031663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa158015611b6c573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611b9091906146b5565b9050428111611ba157505f92915050565b8083602001511115611bb557505f92915050565b60a08301516040808501516001600160a01b039092165f9081526020819052205414611be357505f92915050565b50600192915050565b5f6001600160801b03821115611c1f576040516306dfcc6560e41b815260806004820152602481018390526044016104bc565b5090565b5f516020614a225f395f51905f5280546001600160a01b0319166001600160a01b03831690811782556040519081527f2f658b440c35314f52658ea8a740e05b284cdc84dc9ae01e891f21b8933e7cad90602001610ac4565b611c84610f55565b5f516020614a625f395f51905f52805460ff191660011781557f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258336110bc565b7fa16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d10280546060915f516020614a425f395f51905f5291611d02906146cc565b80601f0160208091040260200160405190810160405280929190818152602001828054611d2e906146cc565b8015611d795780601f10611d5057610100808354040283529160200191611d79565b820191905f5260205f20905b815481529060010190602001808311611d5c57829003601f168201915b505050505091505090565b7fa16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d10380546060915f516020614a425f395f51905f5291611d02906146cc565b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805460011901611e0657604051633ee5aeb560e01b815260040160405180910390fd5b60029055565b60017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f0055565b5f807ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0061086f565b611e626127db565b611e6b81612800565b50565b611e766127db565b610bcc8282612811565b61068f6127db565b611e906127db565b61068f612870565b6040516001600160a01b038085166024830152831660448201526001600160e01b0319821660648201525f908190819060840160408051601f19818403018152918152602080830180516001600160e01b031663b700961360e01b1781525f808052918290528351939450919290918a5afa15611f20575f516020805191945081901c150291505b5094509492505050565b5f516020614a625f395f51905f525460ff1661068f57604051638dfc202b60e01b815260040160405180910390fd5b5f836001600160a01b031682608001516001600160a01b0316148015611fa45750826004811115611f8c57611f8c6144f4565b82606001516004811115611fa257611fa26144f4565b145b90505b9392505050565b5f611fa7835f015160a00151838560200151612878565b5f828218828410028218611fa7565b5f5f5f846060015190505f60675490505f5f611ffb8489608001518a6101000151866128e8565b909250905061200c6012600a6147e1565b8761201784846145e0565b61202191906147ec565b61202b9190614817565b94506120396012600a6147e1565b61204383896147ec565b61204d9190614817565b9550505050509250929050565b60808101515f90600183606001516004811115612079576120796144f4565b0361208a57826080015191506121d9565b6002836060015160048111156120a2576120a26144f4565b0361210e57806001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061210791906144d9565b91506121d9565b600383606001516004811115612126576121266144f4565b0361216757806001600160a01b03166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b60048360600151600481111561217f5761217f6144f4565b036121c057806001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b60405163688c176f60e01b815260040160405180910390fd5b50919050565b60808101515f906001836060015160048111156121fe576121fe6144f4565b0361223f57806001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b600283606001516004811115612257576122576144f4565b0361226857826080015191506121d9565b600383606001516004811115612280576122806144f4565b036122c157806001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b6004836060015160048111156122d9576122d96144f4565b036121d957806001600160a01b03166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa15801561231a573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611fa791906144d9565b6040516001600160a01b0384811660248301528381166044830152606482018390526123a59186918216906323b872dd906084015b604051602081830303815290604052915060e01b6020820180516001600160e01b038381831617835250505050612b7d565b50505050565b604051636eb1769f60e11b81523060048201526001600160a01b0383811660248301525f919085169063dd62ed3e90604401602060405180830381865afa1580156123f8573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061241c91906146b5565b90506123a5848461242d85856145cd565b612be9565b5f5b82518110156123a55782818151811061244f5761244f6144c5565b6020026020010151602001515f0315612540576124bc848281518110612477576124776144c5565b60200260200101515f015160c00151848381518110612498576124986144c5565b60200260200101515f0151846001600160a01b03166125489092919063ffffffff16565b7ffec331350fce78ba658e082a71da20ac9f8d798a99b3c79681c8440cbfe77e076125028583815181106124f2576124f26144c5565b60200260200101515f015161081d565b848381518110612514576125146144c5565b602002602001015160200151604051612537929190918252602082015260400190565b60405180910390a15b600101612434565b6040516001600160a01b0383811660248301526044820183905261067691859182169063a9059cbb90606401612373565b5f8190505f816001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156125ba573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906125de91906144d9565b90505f826001600160a01b03166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa15801561261d573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061264191906144d9565b6040516370a0823160e01b81523060048201529091505f906001600160a01b038416906370a0823190602401602060405180830381865afa158015612688573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906126ac91906146b5565b6040516370a0823160e01b81523060048201529091505f906001600160a01b038716906370a0823190602401602060405180830381865afa1580156126f3573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061271791906146b5565b6040516370a0823160e01b81523060048201529091505f906001600160a01b038516906370a0823190602401602060405180830381865afa15801561275e573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061278291906146b5565b9050821561279e5761279e6001600160a01b0386168985612548565b81156127b8576127b86001600160a01b0388168984612548565b8015610813576108136001600160a01b0385168983612548565b5f61076f612c78565b6127e3612ceb565b61068f57604051631afcd79f60e31b815260040160405180910390fd5b6128086127db565b611e6b81611c23565b6128196127db565b5f516020614a425f395f51905f527fa16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d1026128528482614875565b50600381016128618382614875565b505f8082556001909101555050565b611e0c6127db565b5f836001600160a01b03163b5f036128d6575f5f6128968585612d04565b5090925090505f8160038111156128af576128af6144f4565b1480156128cd5750856001600160a01b0316826001600160a01b0316145b92505050611fa7565b6128e1848484612d4d565b9050611fa7565b5f5f5f6128f486612e24565b90505f61290087612e93565b90505f42886001600160a01b031663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa158015612940573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061296491906146b5565b61296e91906145e0565b90506002896004811115612984576129846144f4565b03612a025782670de0b6b3a764000061299e898486613116565b6129a891906147ec565b6129b29190614817565b945082670de0b6b3a76400006129e7816129cc8a826145e0565b6129d6908c6147ec565b6129e09190614817565b8486613116565b6129f191906147ec565b6129fb9190614817565b9350612b71565b6001896004811115612a1657612a166144f4565b03612a8757612a26878284613116565b612a3884670de0b6b3a76400006147ec565b612a429190614817565b9450612a75670de0b6b3a7640000612a5a88826145cd565b612a64908a6147ec565b612a6e9190614817565b8284613116565b6129f184670de0b6b3a76400006147ec565b6004896004811115612a9b57612a9b6144f4565b03612afe5782670de0b6b3a7640000612ab58984866131a1565b612abf91906147ec565b612ac99190614817565b945082670de0b6b3a76400006129e781612ae38a826145cd565b612aed908c6147ec565b612af79190614817565b84866131a1565b6003896004811115612b1257612b126144f4565b036121c057612b228782846131a1565b612b3484670de0b6b3a76400006147ec565b612b3e9190614817565b9450612a75670de0b6b3a7640000612b5688826145e0565b612b60908a6147ec565b612b6a9190614817565b82846131a1565b50505094509492505050565b5f5f60205f8451602086015f885af180612b9c576040513d5f823e3d81fd5b50505f513d91508115612bb3578060011415612bc0565b6001600160a01b0384163b155b156123a557604051635274afe760e01b81526001600160a01b03851660048201526024016104bc565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180516001600160e01b031663095ea7b360e01b179052612c3a84826131c3565b6123a5576040516001600160a01b0384811660248301525f6044830152612c6e91869182169063095ea7b390606401612373565b6123a58482612b7d565b5f7f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f612ca2613208565b612caa613270565b60408051602081019490945283019190915260608201524660808201523060a082015260c00160405160208183030381529060405280519060200120905090565b5f612cf4611e32565b54600160401b900460ff16919050565b5f5f5f8351604103612d3b576020840151604085015160608601515f1a612d2d888285856132b2565b955095509550505050612d46565b505081515f91506002905b9250925092565b5f5f5f856001600160a01b03168585604051602401612d6d92919061492f565b60408051601f198184030181529181526020820180516001600160e01b0316630b135d3f60e11b17905251612da29190614947565b5f60405180830381855afa9150503d805f8114612dda576040519150601f19603f3d011682016040523d82523d5f602084013e612ddf565b606091505b5091509150818015612df357506020815110155b8015612e1a57508051630b135d3f60e11b90612e1890830160209081019084016146b5565b145b9695505050505050565b5f61086f601260ff16836001600160a01b031663efd98dc26040518163ffffffff1660e01b8152600401602060405180830381865afa158015612e69573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612e8d91906146b5565b9061337a565b5f5f826001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612ed1573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612ef591906144d9565b6001600160a01b031663313ce5676040518163ffffffff1660e01b8152600401602060405180830381865afa158015612f30573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612f54919061495d565b90505f836001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612f93573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612fb791906144d9565b6001600160a01b03166338d52e0f6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612ff2573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061301691906144d9565b6001600160a01b031663313ce5676040518163ffffffff1660e01b8152600401602060405180830381865afa158015613051573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190613075919061495d565b90506130818183614978565b61308c90600a614991565b6001600160a01b038516634cdad5066130a76012600a614991565b6040518263ffffffff1660e01b81526004016130c591815260200190565b602060405180830381865afa1580156130e0573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061310491906146b5565b61310e91906147ec565b949350505050565b5f806301e1338061312f670de0b6b3a7640000866147ec565b613139919061499f565b9050670de0b6b3a76400005f61314f87836149cb565b90505f61315b8261339c565b90505f61317b8461316c87856149f2565b613176919061499f565b613433565b90505f81613189868a6149f2565b613193919061499f565b9a9950505050505050505050565b5f5f6131ae858585613116565b90506131ba81846145e0565b95945050505050565b5f5f5f5f60205f8651602088015f8a5af192503d91505f519050828015612e1a575081156131f45780600114612e1a565b50505050506001600160a01b03163b151590565b5f5f516020614a425f395f51905f5281613220611cc4565b80519091501561323857805160209091012092915050565b81548015613247579392505050565b7fc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470935050505090565b5f5f516020614a425f395f51905f5281613288611d84565b8051909150156132a057805160209091012092915050565b60018201548015613247579392505050565b5f80807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156132eb57505f91506003905082613370565b604080515f808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561333c573d5f5f3e3d5ffd5b5050604051601f1901519150506001600160a01b03811661336757505f925060019150829050613370565b92505f91508190505b9450945094915050565b5f8061338783601b6145e0565b61339290600a6147e1565b9093049392505050565b5f5f82136133dc5760405162461bcd60e51b815260206004820152600d60248201526c6f7574206f6620626f756e647360981b60448201526064016104bc565b670c7d713b49da0000821380156133fa5750670f43fc2c04ee000082125b1561342557670de0b6b3a76400006134118361383f565b8161341e5761341e614803565b0592915050565b61086f8261395c565b919050565b5f680238fd42c5cf03ffff198212158015613457575068070c1cc73b00c800008213155b6134965760405162461bcd60e51b815260206004820152601060248201526f125b9d985b1a5908195e1c1bdb995b9d60821b60448201526064016104bc565b5f8212156134c5576134a9825f03613433565b6a0c097ce7bc90715b34b9f160241b8161341e5761341e614803565b5f6806f05b59d3b2000000831261350457506806f05b59d3b1ffffff1990910190770195e54c5dd42177f53a27172fa9ec63026282700000000061353a565b6803782dace9d9000000831261353657506803782dace9d8ffffff19909101906b1425982cf597cd205cef738061353a565b5060015b6064929092029168056bc75e2d6310000068ad78ebc5ac62000000841261358a5768ad78ebc5ac61ffffff199093019268056bc75e2d631000006e01855144814a7ff805980ff008400082020590505b6856bc75e2d63100000084126135c6576856bc75e2d630ffffff199093019268056bc75e2d631000006b02df0ab5a80a22c61ab5a70082020590505b682b5e3af16b18800000841261360057682b5e3af16b187fffff199093019268056bc75e2d63100000693f1fce3da636ea5cf85082020590505b6815af1d78b58c400000841261363a576815af1d78b58c3fffff199093019268056bc75e2d63100000690127fa27722cc06cc5e282020590505b680ad78ebc5ac6200000841261367357680ad78ebc5ac61fffff199093019268056bc75e2d6310000068280e60114edb805d0382020590505b68056bc75e2d6310000084126136ac5768056bc75e2d630fffff199093019268056bc75e2d63100000680ebc5fb4174612111082020590505b6802b5e3af16b188000084126136e5576802b5e3af16b187ffff199093019268056bc75e2d631000006808f00f760a4b2db55d82020590505b68015af1d78b58c40000841261371e5768015af1d78b58c3ffff199093019268056bc75e2d631000006806f5f177578893793782020590505b68056bc75e2d631000008481019085906002908280020505918201919050600368056bc75e2d631000008783020505918201919050600468056bc75e2d631000008783020505918201919050600568056bc75e2d631000008783020505918201919050600668056bc75e2d631000008783020505918201919050600768056bc75e2d631000008783020505918201919050600868056bc75e2d631000008783020505918201919050600968056bc75e2d631000008783020505918201919050600a68056bc75e2d631000008783020505918201919050600b68056bc75e2d631000008783020505918201919050600c68056bc75e2d631000008783020505918201919050606468056bc75e2d63100000848402058502059695505050505050565b670de0b6b3a7640000025f806a0c097ce7bc90715b34b9f160241b808401906ec097ce7bc90715b34b9f0fffffffff198501028161387f5761387f614803565b0590505f6a0c097ce7bc90715b34b9f160241b82800205905081806a0c097ce7bc90715b34b9f160241b81840205915060038205016a0c097ce7bc90715b34b9f160241b82840205915060058205016a0c097ce7bc90715b34b9f160241b82840205915060078205016a0c097ce7bc90715b34b9f160241b82840205915060098205016a0c097ce7bc90715b34b9f160241b828402059150600b8205016a0c097ce7bc90715b34b9f160241b828402059150600d8205016a0c097ce7bc90715b34b9f160241b828402059150600f82050160020295945050505050565b5f670de0b6b3a764000082121561399b57613993826a0c097ce7bc90715b34b9f160241b8161398d5761398d614803565b0561395c565b5f0392915050565b5f7e1600ef3172e58d2e933ec884fde10064c63b5372d805e203c000000000000083126139eb57770195e54c5dd42177f53a27172fa9ec630262827000000000830592506806f05b59d3b2000000015b73011798004d755d3c8bc8e03204cf44619e0000008312613a23576b1425982cf597cd205cef7380830592506803782dace9d9000000015b606492830292026e01855144814a7ff805980ff00840008312613a6b576e01855144814a7ff805980ff008400068056bc75e2d63100000840205925068ad78ebc5ac62000000015b6b02df0ab5a80a22c61ab5a7008312613aa6576b02df0ab5a80a22c61ab5a70068056bc75e2d6310000084020592506856bc75e2d631000000015b693f1fce3da636ea5cf8508312613add57693f1fce3da636ea5cf85068056bc75e2d631000008402059250682b5e3af16b18800000015b690127fa27722cc06cc5e28312613b1457690127fa27722cc06cc5e268056bc75e2d6310000084020592506815af1d78b58c400000015b68280e60114edb805d038312613b495768280e60114edb805d0368056bc75e2d631000008402059250680ad78ebc5ac6200000015b680ebc5fb417461211108312613b7457680ebc5fb4174612111068056bc75e2d631000009384020592015b6808f00f760a4b2db55d8312613ba9576808f00f760a4b2db55d68056bc75e2d6310000084020592506802b5e3af16b1880000015b6806f5f17757889379378312613bde576806f5f177578893793768056bc75e2d63100000840205925068015af1d78b58c40000015b6806248f33704b2866038312613c12576806248f33704b28660368056bc75e2d63100000840205925067ad78ebc5ac620000015b6805c548670b9510e7ac8312613c46576805c548670b9510e7ac68056bc75e2d6310000084020592506756bc75e2d6310000015b5f68056bc75e2d63100000840168056bc75e2d631000008086030281613c6e57613c6e614803565b0590505f68056bc75e2d63100000828002059050818068056bc75e2d63100000818402059150600382050168056bc75e2d63100000828402059150600582050168056bc75e2d63100000828402059150600782050168056bc75e2d63100000828402059150600982050168056bc75e2d63100000828402059150600b820501600202606485820105979650505050505050565b5f5f83601f840112613d11575f5ffd5b5081356001600160401b03811115613d27575f5ffd5b6020830191508360208260051b8501011115613d41575f5ffd5b9250929050565b5f5f60208385031215613d59575f5ffd5b82356001600160401b03811115613d6e575f5ffd5b613d7a85828601613d01565b90969095509350505050565b5f8151808452602084019350602083015f5b82811015613db6578151865260209586019590910190600101613d98565b5093949350505050565b604081525f613dd26040830185613d86565b82810360208401526131ba8185613d86565b5f5f60208385031215613df5575f5ffd5b82356001600160401b03811115613e0a575f5ffd5b8301601f81018513613e1a575f5ffd5b80356001600160401b03811115613e2f575f5ffd5b85602061012083028401011115613e44575f5ffd5b6020919091019590945092505050565b5f60208284031215613e64575f5ffd5b5035919050565b6001600160a01b0381168114611e6b575f5ffd5b803561342e81613e6b565b634e487b7160e01b5f52604160045260245ffd5b60405161012081016001600160401b0381118282101715613ec157613ec1613e8a565b60405290565b604051608081016001600160401b0381118282101715613ec157613ec1613e8a565b604080519081016001600160401b0381118282101715613ec157613ec1613e8a565b604051601f8201601f191681016001600160401b0381118282101715613f3357613f33613e8a565b604052919050565b5f6001600160401b03821115613f5357613f53613e8a565b5060051b60200190565b80356005811061342e575f5ffd5b5f6101208284031215613f7c575f5ffd5b613f84613e9e565b8235815260208084013590820152604080840135908201529050613faa60608301613f5d565b6060820152613fbb60808301613e7f565b6080820152613fcc60a08301613e7f565b60a0820152613fdd60c08301613e7f565b60c082015260e082810135908201526101009182013591810191909152919050565b5f82601f83011261400e575f5ffd5b81356001600160401b0381111561402757614027613e8a565b61403a601f8201601f1916602001613f0b565b81815284602083860101111561404e575f5ffd5b816020850160208301375f918101602001919091529392505050565b5f61407c61407784613f3b565b613f0b565b838152905060208101600584901b830185811115614098575f5ffd5b835b8181101561412f5780356001600160401b038111156140b7575f5ffd5b850161018081890312156140c9575f5ffd5b6140d1613ec7565b6140db8983613f6b565b81526101208201356001600160401b038111156140f6575f5ffd5b6141028a828501613fff565b6020838101919091526101408401356040840152610160909301356060830152508452928301920161409a565b5050509392505050565b5f82601f830112614148575f5ffd5b611fa78383356020850161406a565b5f5f5f60608486031215614169575f5ffd5b833561417481613e6b565b925060208401356001600160401b0381111561418e575f5ffd5b61419a86828701614139565b92505060408401356001600160401b038111156141b5575f5ffd5b6141c186828701613fff565b9150509250925092565b5f61012082840312156141dc575f5ffd5b611fa78383613f6b565b5f6101208284031280156141f8575f5ffd5b509092915050565b5f60208284031215614210575f5ffd5b8135611fa781613e6b565b60ff81168114611e6b575f5ffd5b5f60208284031215614239575f5ffd5b8135611fa78161421b565b5f81518084528060208401602086015e5f602082860101526020601f19601f83011685010191505092915050565b60ff60f81b8816815260e060208201525f61429060e0830189614244565b82810360408401526142a28189614244565b606084018890526001600160a01b038716608085015260a0840186905283810360c085015290506131938185613d86565b608080825285519082018190525f90602087019060a0840190835b818110156143185783518051845260209081015181850152909301926040909201916001016142ee565b50506001600160a01b0396909616602084015250506040810192909252606090910152919050565b5f5f5f5f5f5f60c08789031215614355575f5ffd5b863561436081613e6b565b955060208701356001600160401b0381111561437a575f5ffd5b61438689828a01614139565b95505060408701356001600160401b038111156143a1575f5ffd5b8701601f810189136143b1575f5ffd5b80356143bf61407782613f3b565b8082825260208201915060208360061b85010192508b8311156143e0575f5ffd5b6020840193505b82841015614427576040848d0312156143fe575f5ffd5b614406613ee9565b843581526020808601358183015290835260409094019391909101906143e7565b96506144399250505060608801613e7f565b9598949750929560808101359460a0909101359350915050565b5f5f5f60608486031215614465575f5ffd5b833561447081613e6b565b9250602084013561448081613e6b565b9150604084013561449081613e6b565b809150509250925092565b5f5f604083850312156144ac575f5ffd5b82356144b781613e6b565b946020939093013593505050565b634e487b7160e01b5f52603260045260245ffd5b5f602082840312156144e9575f5ffd5b8151611fa781613e6b565b634e487b7160e01b5f52602160045260245ffd5b5f6101408201905083825282516020830152602083015160408301526040830151606083015260608301516005811061454f57634e487b7160e01b5f52602160045260245ffd5b80608084015250608083015161457060a08401826001600160a01b03169052565b5060a08301516001600160a01b03811660c08401525060c08301516001600160a01b03811660e08401525060e08301516101008301526101008301516101208301529392505050565b634e487b7160e01b5f52601160045260245ffd5b8082018082111561086f5761086f6145b9565b8181038181111561086f5761086f6145b9565b5f611fa736848461406a565b5f5f8585111561460d575f5ffd5b83861115614619575f5ffd5b5050820193919092039150565b80356001600160e01b03198116906004841015614657576001600160e01b0319600485900360031b81901b82161691505b5092915050565b6001600160a01b03841681526040602082018190528101829052818360608301375f818301606090810191909152601f909201601f1916010192915050565b5f600182016146ae576146ae6145b9565b5060010190565b5f602082840312156146c5575f5ffd5b5051919050565b600181811c908216806146e057607f821691505b6020821081036121d957634e487b7160e01b5f52602260045260245ffd5b6001815b60018411156147395780850481111561471d5761471d6145b9565b600184161561472b57908102905b60019390931c928002614702565b935093915050565b5f8261474f5750600161086f565b8161475b57505f61086f565b8160018114614771576002811461477b57614797565b600191505061086f565b60ff84111561478c5761478c6145b9565b50506001821b61086f565b5060208310610133831016604e8410600b84101617156147ba575081810a61086f565b6147c65f1984846146fe565b805f19048211156147d9576147d96145b9565b029392505050565b5f611fa78383614741565b808202811582820484141761086f5761086f6145b9565b634e487b7160e01b5f52601260045260245ffd5b5f8261482557614825614803565b500490565b601f82111561067657805f5260205f20601f840160051c8101602085101561484f5750805b601f840160051c820191505b8181101561486e575f815560010161485b565b5050505050565b81516001600160401b0381111561488e5761488e613e8a565b6148a28161489c84546146cc565b8461482a565b6020601f8211600181146148d4575f83156148bd5750848201515b5f19600385901b1c1916600184901b17845561486e565b5f84815260208120601f198516915b8281101561490357878501518255602094850194600190920191016148e3565b508482101561492057868401515f19600387901b60f8161c191681555b50505050600190811b01905550565b828152604060208201525f611fa46040830184614244565b5f82518060208501845e5f920191825250919050565b5f6020828403121561496d575f5ffd5b8151611fa78161421b565b60ff828116828216039081111561086f5761086f6145b9565b5f611fa760ff841683614741565b5f826149ad576149ad614803565b600160ff1b82145f19841416156149c6576149c66145b9565b500590565b8082018281125f8312801582168215821617156149ea576149ea6145b9565b505092915050565b8082025f8212600160ff1b84141615614a0d57614a0d6145b9565b818105831482151761086f5761086f6145b956fef3177357ab46d8af007ab3fdb9af81da189e1068fefdc0073dca88a2cab40a00a16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d100cd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300a264697066735822122071496504e1eae5813f7f820f0dd0e14ee6c2cae1e223f0b7de204e7c1f2fea8964736f6c634300081c0033",
+    "sourceMap": "1475:22459:116:-:0;;;2748:132;;;;;;;;;-1:-1:-1;2772:22:116;:20;:22::i;:::-;1475:22459;;7709:422:56;3147:66;7898:15;;;;;;;7894:76;;;7936:23;;-1:-1:-1;;;7936:23:56;;;;;;;;;;;7894:76;7983:14;;-1:-1:-1;;;;;7983:14:56;;;:34;7979:146;;8033:33;;-1:-1:-1;;;;;;8033:33:56;-1:-1:-1;;;;;8033:33:56;;;;;8085:29;;158:50:126;;;8085:29:56;;146:2:126;131:18;8085:29:56;;;;;;;7979:146;7758:373;7709:422::o;14:200:126:-;1475:22459:116;;;;;;",
+    "linkReferences": {}
+  },
+  "deployedBytecode": {
+    "object": "0x608060405234801561000f575f5ffd5b50600436106101c6575f3560e01c806371c707eb116100fe5780638ed9b04b1161009e578063c0d786551161006e578063c0d78655146103e7578063c53a0292146103fa578063cf6fc6e314610402578063f887ea401461042e575f5ffd5b80638ed9b04b146103985780638fb36037146103ab578063bf7e214f146103cc578063c0c53b8b146103d4575f5ffd5b80637b103999116100d95780637b1039991461033f5780638456cb591461035257806384b0196e1461035a5780638b96e39e14610375575f5ffd5b806371c707eb1461030657806372c244a8146103195780637a9e5e4b1461032c575f5ffd5b8063469048401161016957806364278cf61161014457806364278cf6146102ae5780636bec6723146102c15780636ee83986146102d457806370ae92d2146102e7575f5ffd5b806346904840146102585780634cb4069e146102785780635c975abb1461028b575f5ffd5b80633b733c66116101a45780633b733c66146102195780633e076174146102285780633f4ba83a1461023d578063458edd7414610245575f5ffd5b80630c0b8c9c146101ca57806334b08c05146101f457806335ee3ffc14610206575b5f5ffd5b6101dd6101d8366004613d48565b610441565b6040516101eb929190613dc0565b60405180910390f35b6067545b6040519081526020016101eb565b6101dd610214366004613d48565b6104fb565b6101f8670de0b6b3a764000081565b61023b610236366004613de4565b61063b565b005b61023b61067b565b61023b610253366004613e54565b610691565b610260610704565b6040516001600160a01b0390911681526020016101eb565b61023b610286366004614157565b610774565b5f516020614a625f395f51905f525460ff165b60405190151581526020016101eb565b6101f86102bc3660046141cb565b61081d565b61023b6102cf3660046141e6565b610875565b61023b6102e2366004613de4565b6109b8565b6101f86102f5366004614200565b5f6020819052908152604090205481565b61023b6103143660046141e6565b6109eb565b61023b610327366004614229565b610ad0565b61023b61033a366004614200565b610b4a565b606654610260906001600160a01b031681565b61023b610bd0565b610362610be1565b6040516101eb9796959493929190614272565b610388610383366004613d48565b610c8a565b6040516101eb94939291906142d3565b61023b6103a6366004614340565b610cc1565b6103b3610d18565b6040516001600160e01b031990911681526020016101eb565b610260610d4e565b61023b6103e2366004614453565b610d69565b61023b6103f5366004614200565b610ef9565b61023b610f4b565b61029e61041036600461449b565b6001600160a01b03919091165f908152602081905260409020541490565b606554610260906001600160a01b031681565b60608061044e84846104fb565b90925090505f5b82518110156104f3575f6001600160801b031683828151811061047a5761047a6144c5565b6020026020010151036104c557848482818110610499576104996144c5565b905060200201356040516384a19ff760e01b81526004016104bc91815260200190565b60405180910390fd5b60018382815181106104d9576104d96144c5565b602090810291909101018051919091039052600101610455565b509250929050565b60608082806001600160401b0381111561051757610517613e8a565b604051908082528060200260200182016040528015610540578160200160208202803683370190505b509250806001600160401b0381111561055b5761055b613e8a565b604051908082528060200260200182016040528015610584578160200160208202803683370190505b5091505f5b81811015610632575f60685f8888858181106105a7576105a76144c5565b602090810292909201358352508181019290925260409081015f208151808301909252546001600160801b03808216808452600160801b9092041692820183905287519193509190879085908110610601576106016144c5565b6020026020010186858151811061061a5761061a6144c5565b60209081029190910101919091525250600101610589565b50509250929050565b610643610f55565b5f5b818110156106765761066e838383818110610662576106626144c5565b90506101200201610875565b600101610645565b505050565b610687335b5f36610f85565b61068f61107b565b565b61069a33610680565b670de0b6b3a76400008111156106c3576040516315118d7560e11b815260040160405180910390fd5b60675460408051918252602082018390527fb56ebecadafe35f0143935e7910bba2164278066a327a34cc9d11a8a7fa172b4910160405180910390a1606755565b606654604080516312fde4b760e01b815290515f926001600160a01b0316916312fde4b79160048083019260209291908290030181865afa15801561074b573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061076f91906144d9565b905090565b61077c6110da565b610784610f55565b5f8180602001905181019061079991906144d9565b90505f5f5f5f6107a887611105565b93509350935093506107ba87856114dc565b610805875f815181106107cf576107cf6144c5565b60200260200101515f015160800151885f815181106107f0576107f06144c5565b60200260200101515f0151606001518761159b565b6108138888868686866119a5565b5050505050505050565b5f61086f7f1c3eac1da0ab9cb83b042d46ed8a1047556ac9c02e1cb540a4971ee333c7cc4283604051602001610854929190614508565b60405160208183030381529060405280519060200120611aec565b92915050565b61087d610f55565b3361088e60c0830160a08401614200565b6001600160a01b0316146108b55760405163b331e42160e01b815260040160405180910390fd5b60e081013515806108da57506108d86108d3368390038301836141cb565b611b18565b155b156108f85760405163756e10b960e11b815260040160405180910390fd5b5f61090b6102bc368490038401846141cb565b5f818152606860205260409020549091506001600160801b0316156109465760405163aa61587160e01b8152600481018290526024016104bc565b61095d61095860e084013560016145cd565b611bec565b5f8281526068602052604080822080546001600160801b0319166001600160801b0394909416939093179092559051339183917f9645e207a42485247ea4cb002af5c3aa3232570ae805ee4ca3eee263a68895ee9190a35050565b5f5b81811015610676576109e38383838181106109d7576109d76144c5565b905061012002016109eb565b6001016109ba565b336109fc60c0830160a08401614200565b6001600160a01b031614610a235760405163b331e42160e01b815260040160405180910390fd5b5f610a366102bc368490038401846141cb565b5f818152606860205260409020549091506001600160801b03165f1901610a735760405163cee8144360e01b8152600481018290526024016104bc565b5f8181526068602090815260409182902080546001600160801b031916600117905581513381529081018390527f35ab4a1a0e9bec7fd7ae164679b9cc00e6568e4db238d8055a75b1862f62ec2e91015b60405180910390a15050565b335f90815260208190526040812054610aed9060ff8416906145cd565b335f8181526020819052604090208290559091507fdc0537f71d06d3708f52baf4ddf6918b25f1a145ba08873de27485682b35cac1610b2f60ff8516846145e0565b60408051918252602082018590520160405180910390a25050565b33610b53610d4e565b6001600160a01b0316816001600160a01b031614610b8e5760405162d1953b60e31b81526001600160a01b03821660048201526024016104bc565b816001600160a01b03163b5f03610bc3576040516361798f2f60e11b81526001600160a01b03831660048201526024016104bc565b610bcc82611c23565b5050565b610bd933610680565b61068f611c7c565b5f60608082808083815f516020614a425f395f51905f528054909150158015610c0c57506001810154155b610c505760405162461bcd60e51b81526020600482015260156024820152741152540dcc4c8e88155b9a5b9a5d1a585b1a5e9959605a1b60448201526064016104bc565b610c58611cc4565b610c60611d84565b604080515f80825260208201909252600f60f81b9c939b5091995046985030975095509350915050565b60605f5f5f610c976110da565b610c9f610f55565b610cb1610cac86886145f3565b611105565b9299919850965090945092505050565b610cc96110da565b610cd1610f55565b610cd9611dc2565b610ce78686868686866119a5565b610d1060017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f0055565b505050505050565b5f516020614a225f395f51905f5280545f9190600160a01b900460ff16610d3f575f610d48565b638fb3603760e01b5b91505090565b5f516020614a225f395f51905f52546001600160a01b031690565b5f610d72611e32565b805490915060ff600160401b82041615906001600160401b03165f81158015610d985750825b90505f826001600160401b03166001148015610db35750303b155b905081158015610dc1575080155b15610ddf5760405163f92ee8a960e01b815260040160405180910390fd5b845467ffffffffffffffff191660011785558315610e0957845460ff60401b1916600160401b1785555b610e1286611e5a565b610e6a6040518060400160405280601c81526020017f53706563747261204c696d6974204f726465722050726f746f636f6c00000000815250604051806040016040528060018152602001603160f81b815250611e6e565b610e72611e80565b610e7a611e88565b606680546001600160a01b03808b166001600160a01b03199283161790925560658054928a1692909116919091179055831561081357845460ff60401b19168555604051600181527fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d29060200160405180910390a15050505050505050565b610f0233610680565b606580546001600160a01b0319166001600160a01b0383169081179091556040517f7aed1d3e8155a07ccf395e44ea3109a0e2d6c9b29bbbe9f142d9790596f4dc80905f90a250565b61068f6001610ad0565b5f516020614a625f395f51905f525460ff161561068f5760405163d93c066560e01b815260040160405180910390fd5b5f516020614a225f395f51905f525f80610fbd610fa0610d4e565b8730610faf60045f8a8c6145ff565b610fb891614626565b611e98565b9150915081610d105763ffffffff81161561105857825460ff60a01b1916600160a01b178355610feb610d4e565b6001600160a01b03166394c7d7ee8787876040518463ffffffff1660e01b815260040161101a9392919061465e565b5f604051808303815f87803b158015611031575f5ffd5b505af1158015611043573d5f5f3e3d5ffd5b5050845460ff60a01b1916855550610d109050565b60405162d1953b60e31b81526001600160a01b03871660048201526024016104bc565b611083611f2a565b5f516020614a625f395f51905f52805460ff191681557f5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa335b6040516001600160a01b03909116815260200160405180910390a150565b6065546001600160a01b0316331461068f57604051639165520160e01b815260040160405180910390fd5b60605f5f5f5f5f865f8151811061111e5761111e6144c5565b60200260200101515f015160600151905086516001600160401b0381111561114857611148613e8a565b60405190808252806020026020018201604052801561118c57816020015b604080518082019091525f80825260208201528152602001906001900390816111665790505b5095505f5b87518110156114b1575f8882815181106111ad576111ad6144c5565b60200260200101515f015190506111e5895f815181106111cf576111cf6144c5565b60200260200101515f0151608001518483611f59565b6112055760405160016205f80f60e41b0319815260040160405180910390fd5b61120e81611b18565b6112235761121b8461469d565b9350506114a9565b5f61122d8261081d565b5f818152606860205260408120549192506001600160801b0390911615801591906112a8575f838152606860205260409020546001600160801b031660011480156112875761127b8861469d565b975050505050506114a9565b50505f828152606860205260409020546001600160801b03165f19016112e4565b5f6112cc8d87815181106112be576112be6144c5565b602002602001015185611fae565b9050806112dc5761127b8861469d565b505060e08301515b5f61130c828e88815181106112fb576112fb6144c5565b602002602001015160400151611fc5565b90508082039150604051806040016040528061132a84600101611bec565b6001600160801b0390811682525f8781526068602090815260409091205492019161135f91600160801b909104168401611bec565b6001600160801b039081169091525f8681526068602090815260408083208551958301518516600160801b0295909416949094179092558251808401909352808352908201526113af8683611fd4565b602083015281528d518e90889081106113ca576113ca6144c5565b6020026020010151606001518160200151825f01516113e991906145cd565b11156114085760405163a28213a360e01b815260040160405180910390fd5b6020810151815161141991906145cd565b611423908c6145cd565b9a5080602001518a61143591906145cd565b99506040518060400160405280825f01518152602001838152508d8881518110611461576114616144c5565b60209081029190910101526001600160a01b038c166114a25761149f8e888151811061148f5761148f6144c5565b60200260200101515f015161205a565b9b505b5050505050505b600101611191565b50865182036114d357604051639bc0260d60e01b815260040160405180910390fd5b50509193509193565b5f5b8151811015610676578181815181106114f9576114f96144c5565b6020026020010151602001515f0315611593575f611532848381518110611522576115226144c5565b60200260200101515f01516121df565b9050611591848381518110611549576115496144c5565b60200260200101515f015160a001513085858151811061156b5761156b6144c5565b602002602001015160200151846001600160a01b031661233e909392919063ffffffff16565b505b6001016114de565b5f8390505f816001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156115dc573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061160091906144d9565b90505f826001600160a01b03166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa15801561163f573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061166391906144d9565b9050816001600160a01b0316846001600160a01b03161480156116b257506001856004811115611695576116956144f4565b14806116b2575060038560048111156116b0576116b06144f4565b145b156117b8576040516370a0823160e01b81523060048201525f906001600160a01b038416906370a0823190602401602060405180830381865afa1580156116fb573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061171f91906146b5565b905080156117b25761173b6001600160a01b03841688836123ab565b604051632eb7f01d60e21b815260048101829052306024820181905260448201526001600160a01b0385169063badfc074906064016020604051808303815f875af115801561178c573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906117b091906146b5565b505b50610d10565b856001600160a01b0316846001600160a01b03161480156117ea575060048560048111156117e8576117e86144f4565b145b806118225750806001600160a01b0316846001600160a01b031614801561182257506002856004811115611820576118206144f4565b145b15610d10576040516370a0823160e01b81523060048201525f906001600160a01b038816906370a0823190602401602060405180830381865afa15801561186b573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061188f91906146b5565b6040516370a0823160e01b81523060048201529091505f906001600160a01b038416906370a0823190602401602060405180830381865afa1580156118d6573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906118fa91906146b5565b90505f6119078383611fc5565b9050801561199a576119236001600160a01b0385168a836123ab565b60405163b2afd5a360e01b815260048101829052306024820181905260448201526001600160a01b0387169063b2afd5a3906064016020604051808303815f875af1158015611974573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061199891906146b5565b505b505050505050505050565b845115806119b557508351855114155b156119d3576040516305373a5b60e41b815260040160405180910390fd5b6001600160a01b03861615806119f057506001600160a01b038316155b15611a0e576040516305373a5b60e41b815260040160405180910390fd5b6040516370a0823160e01b815230600482015282906001600160a01b038516906370a0823190602401602060405180830381865afa158015611a52573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611a7691906146b5565b1015611a955760405163356680b760e01b815260040160405180910390fd5b611aa0858585612432565b8015611ac257611ac2611ab1610704565b6001600160a01b0385169083612548565b610d1086865f81518110611ad857611ad86144c5565b60200260200101515f015160800151612579565b5f61086f611af86127d2565b8360405161190160f01b8152600281019290925260228201526042902090565b5f42826020015111611b2b57505f919050565b5f82608001516001600160a01b031663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa158015611b6c573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611b9091906146b5565b9050428111611ba157505f92915050565b8083602001511115611bb557505f92915050565b60a08301516040808501516001600160a01b039092165f9081526020819052205414611be357505f92915050565b50600192915050565b5f6001600160801b03821115611c1f576040516306dfcc6560e41b815260806004820152602481018390526044016104bc565b5090565b5f516020614a225f395f51905f5280546001600160a01b0319166001600160a01b03831690811782556040519081527f2f658b440c35314f52658ea8a740e05b284cdc84dc9ae01e891f21b8933e7cad90602001610ac4565b611c84610f55565b5f516020614a625f395f51905f52805460ff191660011781557f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258336110bc565b7fa16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d10280546060915f516020614a425f395f51905f5291611d02906146cc565b80601f0160208091040260200160405190810160405280929190818152602001828054611d2e906146cc565b8015611d795780601f10611d5057610100808354040283529160200191611d79565b820191905f5260205f20905b815481529060010190602001808311611d5c57829003601f168201915b505050505091505090565b7fa16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d10380546060915f516020614a425f395f51905f5291611d02906146cc565b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f00805460011901611e0657604051633ee5aeb560e01b815260040160405180910390fd5b60029055565b60017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f0055565b5f807ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a0061086f565b611e626127db565b611e6b81612800565b50565b611e766127db565b610bcc8282612811565b61068f6127db565b611e906127db565b61068f612870565b6040516001600160a01b038085166024830152831660448201526001600160e01b0319821660648201525f908190819060840160408051601f19818403018152918152602080830180516001600160e01b031663b700961360e01b1781525f808052918290528351939450919290918a5afa15611f20575f516020805191945081901c150291505b5094509492505050565b5f516020614a625f395f51905f525460ff1661068f57604051638dfc202b60e01b815260040160405180910390fd5b5f836001600160a01b031682608001516001600160a01b0316148015611fa45750826004811115611f8c57611f8c6144f4565b82606001516004811115611fa257611fa26144f4565b145b90505b9392505050565b5f611fa7835f015160a00151838560200151612878565b5f828218828410028218611fa7565b5f5f5f846060015190505f60675490505f5f611ffb8489608001518a6101000151866128e8565b909250905061200c6012600a6147e1565b8761201784846145e0565b61202191906147ec565b61202b9190614817565b94506120396012600a6147e1565b61204383896147ec565b61204d9190614817565b9550505050509250929050565b60808101515f90600183606001516004811115612079576120796144f4565b0361208a57826080015191506121d9565b6002836060015160048111156120a2576120a26144f4565b0361210e57806001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061210791906144d9565b91506121d9565b600383606001516004811115612126576121266144f4565b0361216757806001600160a01b03166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b60048360600151600481111561217f5761217f6144f4565b036121c057806001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b60405163688c176f60e01b815260040160405180910390fd5b50919050565b60808101515f906001836060015160048111156121fe576121fe6144f4565b0361223f57806001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b600283606001516004811115612257576122576144f4565b0361226857826080015191506121d9565b600383606001516004811115612280576122806144f4565b036122c157806001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156120e3573d5f5f3e3d5ffd5b6004836060015160048111156122d9576122d96144f4565b036121d957806001600160a01b03166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa15801561231a573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611fa791906144d9565b6040516001600160a01b0384811660248301528381166044830152606482018390526123a59186918216906323b872dd906084015b604051602081830303815290604052915060e01b6020820180516001600160e01b038381831617835250505050612b7d565b50505050565b604051636eb1769f60e11b81523060048201526001600160a01b0383811660248301525f919085169063dd62ed3e90604401602060405180830381865afa1580156123f8573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061241c91906146b5565b90506123a5848461242d85856145cd565b612be9565b5f5b82518110156123a55782818151811061244f5761244f6144c5565b6020026020010151602001515f0315612540576124bc848281518110612477576124776144c5565b60200260200101515f015160c00151848381518110612498576124986144c5565b60200260200101515f0151846001600160a01b03166125489092919063ffffffff16565b7ffec331350fce78ba658e082a71da20ac9f8d798a99b3c79681c8440cbfe77e076125028583815181106124f2576124f26144c5565b60200260200101515f015161081d565b848381518110612514576125146144c5565b602002602001015160200151604051612537929190918252602082015260400190565b60405180910390a15b600101612434565b6040516001600160a01b0383811660248301526044820183905261067691859182169063a9059cbb90606401612373565b5f8190505f816001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa1580156125ba573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906125de91906144d9565b90505f826001600160a01b03166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa15801561261d573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061264191906144d9565b6040516370a0823160e01b81523060048201529091505f906001600160a01b038416906370a0823190602401602060405180830381865afa158015612688573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906126ac91906146b5565b6040516370a0823160e01b81523060048201529091505f906001600160a01b038716906370a0823190602401602060405180830381865afa1580156126f3573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061271791906146b5565b6040516370a0823160e01b81523060048201529091505f906001600160a01b038516906370a0823190602401602060405180830381865afa15801561275e573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061278291906146b5565b9050821561279e5761279e6001600160a01b0386168985612548565b81156127b8576127b86001600160a01b0388168984612548565b8015610813576108136001600160a01b0385168983612548565b5f61076f612c78565b6127e3612ceb565b61068f57604051631afcd79f60e31b815260040160405180910390fd5b6128086127db565b611e6b81611c23565b6128196127db565b5f516020614a425f395f51905f527fa16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d1026128528482614875565b50600381016128618382614875565b505f8082556001909101555050565b611e0c6127db565b5f836001600160a01b03163b5f036128d6575f5f6128968585612d04565b5090925090505f8160038111156128af576128af6144f4565b1480156128cd5750856001600160a01b0316826001600160a01b0316145b92505050611fa7565b6128e1848484612d4d565b9050611fa7565b5f5f5f6128f486612e24565b90505f61290087612e93565b90505f42886001600160a01b031663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa158015612940573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061296491906146b5565b61296e91906145e0565b90506002896004811115612984576129846144f4565b03612a025782670de0b6b3a764000061299e898486613116565b6129a891906147ec565b6129b29190614817565b945082670de0b6b3a76400006129e7816129cc8a826145e0565b6129d6908c6147ec565b6129e09190614817565b8486613116565b6129f191906147ec565b6129fb9190614817565b9350612b71565b6001896004811115612a1657612a166144f4565b03612a8757612a26878284613116565b612a3884670de0b6b3a76400006147ec565b612a429190614817565b9450612a75670de0b6b3a7640000612a5a88826145cd565b612a64908a6147ec565b612a6e9190614817565b8284613116565b6129f184670de0b6b3a76400006147ec565b6004896004811115612a9b57612a9b6144f4565b03612afe5782670de0b6b3a7640000612ab58984866131a1565b612abf91906147ec565b612ac99190614817565b945082670de0b6b3a76400006129e781612ae38a826145cd565b612aed908c6147ec565b612af79190614817565b84866131a1565b6003896004811115612b1257612b126144f4565b036121c057612b228782846131a1565b612b3484670de0b6b3a76400006147ec565b612b3e9190614817565b9450612a75670de0b6b3a7640000612b5688826145e0565b612b60908a6147ec565b612b6a9190614817565b82846131a1565b50505094509492505050565b5f5f60205f8451602086015f885af180612b9c576040513d5f823e3d81fd5b50505f513d91508115612bb3578060011415612bc0565b6001600160a01b0384163b155b156123a557604051635274afe760e01b81526001600160a01b03851660048201526024016104bc565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180516001600160e01b031663095ea7b360e01b179052612c3a84826131c3565b6123a5576040516001600160a01b0384811660248301525f6044830152612c6e91869182169063095ea7b390606401612373565b6123a58482612b7d565b5f7f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f612ca2613208565b612caa613270565b60408051602081019490945283019190915260608201524660808201523060a082015260c00160405160208183030381529060405280519060200120905090565b5f612cf4611e32565b54600160401b900460ff16919050565b5f5f5f8351604103612d3b576020840151604085015160608601515f1a612d2d888285856132b2565b955095509550505050612d46565b505081515f91506002905b9250925092565b5f5f5f856001600160a01b03168585604051602401612d6d92919061492f565b60408051601f198184030181529181526020820180516001600160e01b0316630b135d3f60e11b17905251612da29190614947565b5f60405180830381855afa9150503d805f8114612dda576040519150601f19603f3d011682016040523d82523d5f602084013e612ddf565b606091505b5091509150818015612df357506020815110155b8015612e1a57508051630b135d3f60e11b90612e1890830160209081019084016146b5565b145b9695505050505050565b5f61086f601260ff16836001600160a01b031663efd98dc26040518163ffffffff1660e01b8152600401602060405180830381865afa158015612e69573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612e8d91906146b5565b9061337a565b5f5f826001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612ed1573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612ef591906144d9565b6001600160a01b031663313ce5676040518163ffffffff1660e01b8152600401602060405180830381865afa158015612f30573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612f54919061495d565b90505f836001600160a01b031663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612f93573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612fb791906144d9565b6001600160a01b03166338d52e0f6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612ff2573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061301691906144d9565b6001600160a01b031663313ce5676040518163ffffffff1660e01b8152600401602060405180830381865afa158015613051573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190613075919061495d565b90506130818183614978565b61308c90600a614991565b6001600160a01b038516634cdad5066130a76012600a614991565b6040518263ffffffff1660e01b81526004016130c591815260200190565b602060405180830381865afa1580156130e0573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061310491906146b5565b61310e91906147ec565b949350505050565b5f806301e1338061312f670de0b6b3a7640000866147ec565b613139919061499f565b9050670de0b6b3a76400005f61314f87836149cb565b90505f61315b8261339c565b90505f61317b8461316c87856149f2565b613176919061499f565b613433565b90505f81613189868a6149f2565b613193919061499f565b9a9950505050505050505050565b5f5f6131ae858585613116565b90506131ba81846145e0565b95945050505050565b5f5f5f5f60205f8651602088015f8a5af192503d91505f519050828015612e1a575081156131f45780600114612e1a565b50505050506001600160a01b03163b151590565b5f5f516020614a425f395f51905f5281613220611cc4565b80519091501561323857805160209091012092915050565b81548015613247579392505050565b7fc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470935050505090565b5f5f516020614a425f395f51905f5281613288611d84565b8051909150156132a057805160209091012092915050565b60018201548015613247579392505050565b5f80807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a08411156132eb57505f91506003905082613370565b604080515f808252602082018084528a905260ff891692820192909252606081018790526080810186905260019060a0016020604051602081039080840390855afa15801561333c573d5f5f3e3d5ffd5b5050604051601f1901519150506001600160a01b03811661336757505f925060019150829050613370565b92505f91508190505b9450945094915050565b5f8061338783601b6145e0565b61339290600a6147e1565b9093049392505050565b5f5f82136133dc5760405162461bcd60e51b815260206004820152600d60248201526c6f7574206f6620626f756e647360981b60448201526064016104bc565b670c7d713b49da0000821380156133fa5750670f43fc2c04ee000082125b1561342557670de0b6b3a76400006134118361383f565b8161341e5761341e614803565b0592915050565b61086f8261395c565b919050565b5f680238fd42c5cf03ffff198212158015613457575068070c1cc73b00c800008213155b6134965760405162461bcd60e51b815260206004820152601060248201526f125b9d985b1a5908195e1c1bdb995b9d60821b60448201526064016104bc565b5f8212156134c5576134a9825f03613433565b6a0c097ce7bc90715b34b9f160241b8161341e5761341e614803565b5f6806f05b59d3b2000000831261350457506806f05b59d3b1ffffff1990910190770195e54c5dd42177f53a27172fa9ec63026282700000000061353a565b6803782dace9d9000000831261353657506803782dace9d8ffffff19909101906b1425982cf597cd205cef738061353a565b5060015b6064929092029168056bc75e2d6310000068ad78ebc5ac62000000841261358a5768ad78ebc5ac61ffffff199093019268056bc75e2d631000006e01855144814a7ff805980ff008400082020590505b6856bc75e2d63100000084126135c6576856bc75e2d630ffffff199093019268056bc75e2d631000006b02df0ab5a80a22c61ab5a70082020590505b682b5e3af16b18800000841261360057682b5e3af16b187fffff199093019268056bc75e2d63100000693f1fce3da636ea5cf85082020590505b6815af1d78b58c400000841261363a576815af1d78b58c3fffff199093019268056bc75e2d63100000690127fa27722cc06cc5e282020590505b680ad78ebc5ac6200000841261367357680ad78ebc5ac61fffff199093019268056bc75e2d6310000068280e60114edb805d0382020590505b68056bc75e2d6310000084126136ac5768056bc75e2d630fffff199093019268056bc75e2d63100000680ebc5fb4174612111082020590505b6802b5e3af16b188000084126136e5576802b5e3af16b187ffff199093019268056bc75e2d631000006808f00f760a4b2db55d82020590505b68015af1d78b58c40000841261371e5768015af1d78b58c3ffff199093019268056bc75e2d631000006806f5f177578893793782020590505b68056bc75e2d631000008481019085906002908280020505918201919050600368056bc75e2d631000008783020505918201919050600468056bc75e2d631000008783020505918201919050600568056bc75e2d631000008783020505918201919050600668056bc75e2d631000008783020505918201919050600768056bc75e2d631000008783020505918201919050600868056bc75e2d631000008783020505918201919050600968056bc75e2d631000008783020505918201919050600a68056bc75e2d631000008783020505918201919050600b68056bc75e2d631000008783020505918201919050600c68056bc75e2d631000008783020505918201919050606468056bc75e2d63100000848402058502059695505050505050565b670de0b6b3a7640000025f806a0c097ce7bc90715b34b9f160241b808401906ec097ce7bc90715b34b9f0fffffffff198501028161387f5761387f614803565b0590505f6a0c097ce7bc90715b34b9f160241b82800205905081806a0c097ce7bc90715b34b9f160241b81840205915060038205016a0c097ce7bc90715b34b9f160241b82840205915060058205016a0c097ce7bc90715b34b9f160241b82840205915060078205016a0c097ce7bc90715b34b9f160241b82840205915060098205016a0c097ce7bc90715b34b9f160241b828402059150600b8205016a0c097ce7bc90715b34b9f160241b828402059150600d8205016a0c097ce7bc90715b34b9f160241b828402059150600f82050160020295945050505050565b5f670de0b6b3a764000082121561399b57613993826a0c097ce7bc90715b34b9f160241b8161398d5761398d614803565b0561395c565b5f0392915050565b5f7e1600ef3172e58d2e933ec884fde10064c63b5372d805e203c000000000000083126139eb57770195e54c5dd42177f53a27172fa9ec630262827000000000830592506806f05b59d3b2000000015b73011798004d755d3c8bc8e03204cf44619e0000008312613a23576b1425982cf597cd205cef7380830592506803782dace9d9000000015b606492830292026e01855144814a7ff805980ff00840008312613a6b576e01855144814a7ff805980ff008400068056bc75e2d63100000840205925068ad78ebc5ac62000000015b6b02df0ab5a80a22c61ab5a7008312613aa6576b02df0ab5a80a22c61ab5a70068056bc75e2d6310000084020592506856bc75e2d631000000015b693f1fce3da636ea5cf8508312613add57693f1fce3da636ea5cf85068056bc75e2d631000008402059250682b5e3af16b18800000015b690127fa27722cc06cc5e28312613b1457690127fa27722cc06cc5e268056bc75e2d6310000084020592506815af1d78b58c400000015b68280e60114edb805d038312613b495768280e60114edb805d0368056bc75e2d631000008402059250680ad78ebc5ac6200000015b680ebc5fb417461211108312613b7457680ebc5fb4174612111068056bc75e2d631000009384020592015b6808f00f760a4b2db55d8312613ba9576808f00f760a4b2db55d68056bc75e2d6310000084020592506802b5e3af16b1880000015b6806f5f17757889379378312613bde576806f5f177578893793768056bc75e2d63100000840205925068015af1d78b58c40000015b6806248f33704b2866038312613c12576806248f33704b28660368056bc75e2d63100000840205925067ad78ebc5ac620000015b6805c548670b9510e7ac8312613c46576805c548670b9510e7ac68056bc75e2d6310000084020592506756bc75e2d6310000015b5f68056bc75e2d63100000840168056bc75e2d631000008086030281613c6e57613c6e614803565b0590505f68056bc75e2d63100000828002059050818068056bc75e2d63100000818402059150600382050168056bc75e2d63100000828402059150600582050168056bc75e2d63100000828402059150600782050168056bc75e2d63100000828402059150600982050168056bc75e2d63100000828402059150600b820501600202606485820105979650505050505050565b5f5f83601f840112613d11575f5ffd5b5081356001600160401b03811115613d27575f5ffd5b6020830191508360208260051b8501011115613d41575f5ffd5b9250929050565b5f5f60208385031215613d59575f5ffd5b82356001600160401b03811115613d6e575f5ffd5b613d7a85828601613d01565b90969095509350505050565b5f8151808452602084019350602083015f5b82811015613db6578151865260209586019590910190600101613d98565b5093949350505050565b604081525f613dd26040830185613d86565b82810360208401526131ba8185613d86565b5f5f60208385031215613df5575f5ffd5b82356001600160401b03811115613e0a575f5ffd5b8301601f81018513613e1a575f5ffd5b80356001600160401b03811115613e2f575f5ffd5b85602061012083028401011115613e44575f5ffd5b6020919091019590945092505050565b5f60208284031215613e64575f5ffd5b5035919050565b6001600160a01b0381168114611e6b575f5ffd5b803561342e81613e6b565b634e487b7160e01b5f52604160045260245ffd5b60405161012081016001600160401b0381118282101715613ec157613ec1613e8a565b60405290565b604051608081016001600160401b0381118282101715613ec157613ec1613e8a565b604080519081016001600160401b0381118282101715613ec157613ec1613e8a565b604051601f8201601f191681016001600160401b0381118282101715613f3357613f33613e8a565b604052919050565b5f6001600160401b03821115613f5357613f53613e8a565b5060051b60200190565b80356005811061342e575f5ffd5b5f6101208284031215613f7c575f5ffd5b613f84613e9e565b8235815260208084013590820152604080840135908201529050613faa60608301613f5d565b6060820152613fbb60808301613e7f565b6080820152613fcc60a08301613e7f565b60a0820152613fdd60c08301613e7f565b60c082015260e082810135908201526101009182013591810191909152919050565b5f82601f83011261400e575f5ffd5b81356001600160401b0381111561402757614027613e8a565b61403a601f8201601f1916602001613f0b565b81815284602083860101111561404e575f5ffd5b816020850160208301375f918101602001919091529392505050565b5f61407c61407784613f3b565b613f0b565b838152905060208101600584901b830185811115614098575f5ffd5b835b8181101561412f5780356001600160401b038111156140b7575f5ffd5b850161018081890312156140c9575f5ffd5b6140d1613ec7565b6140db8983613f6b565b81526101208201356001600160401b038111156140f6575f5ffd5b6141028a828501613fff565b6020838101919091526101408401356040840152610160909301356060830152508452928301920161409a565b5050509392505050565b5f82601f830112614148575f5ffd5b611fa78383356020850161406a565b5f5f5f60608486031215614169575f5ffd5b833561417481613e6b565b925060208401356001600160401b0381111561418e575f5ffd5b61419a86828701614139565b92505060408401356001600160401b038111156141b5575f5ffd5b6141c186828701613fff565b9150509250925092565b5f61012082840312156141dc575f5ffd5b611fa78383613f6b565b5f6101208284031280156141f8575f5ffd5b509092915050565b5f60208284031215614210575f5ffd5b8135611fa781613e6b565b60ff81168114611e6b575f5ffd5b5f60208284031215614239575f5ffd5b8135611fa78161421b565b5f81518084528060208401602086015e5f602082860101526020601f19601f83011685010191505092915050565b60ff60f81b8816815260e060208201525f61429060e0830189614244565b82810360408401526142a28189614244565b606084018890526001600160a01b038716608085015260a0840186905283810360c085015290506131938185613d86565b608080825285519082018190525f90602087019060a0840190835b818110156143185783518051845260209081015181850152909301926040909201916001016142ee565b50506001600160a01b0396909616602084015250506040810192909252606090910152919050565b5f5f5f5f5f5f60c08789031215614355575f5ffd5b863561436081613e6b565b955060208701356001600160401b0381111561437a575f5ffd5b61438689828a01614139565b95505060408701356001600160401b038111156143a1575f5ffd5b8701601f810189136143b1575f5ffd5b80356143bf61407782613f3b565b8082825260208201915060208360061b85010192508b8311156143e0575f5ffd5b6020840193505b82841015614427576040848d0312156143fe575f5ffd5b614406613ee9565b843581526020808601358183015290835260409094019391909101906143e7565b96506144399250505060608801613e7f565b9598949750929560808101359460a0909101359350915050565b5f5f5f60608486031215614465575f5ffd5b833561447081613e6b565b9250602084013561448081613e6b565b9150604084013561449081613e6b565b809150509250925092565b5f5f604083850312156144ac575f5ffd5b82356144b781613e6b565b946020939093013593505050565b634e487b7160e01b5f52603260045260245ffd5b5f602082840312156144e9575f5ffd5b8151611fa781613e6b565b634e487b7160e01b5f52602160045260245ffd5b5f6101408201905083825282516020830152602083015160408301526040830151606083015260608301516005811061454f57634e487b7160e01b5f52602160045260245ffd5b80608084015250608083015161457060a08401826001600160a01b03169052565b5060a08301516001600160a01b03811660c08401525060c08301516001600160a01b03811660e08401525060e08301516101008301526101008301516101208301529392505050565b634e487b7160e01b5f52601160045260245ffd5b8082018082111561086f5761086f6145b9565b8181038181111561086f5761086f6145b9565b5f611fa736848461406a565b5f5f8585111561460d575f5ffd5b83861115614619575f5ffd5b5050820193919092039150565b80356001600160e01b03198116906004841015614657576001600160e01b0319600485900360031b81901b82161691505b5092915050565b6001600160a01b03841681526040602082018190528101829052818360608301375f818301606090810191909152601f909201601f1916010192915050565b5f600182016146ae576146ae6145b9565b5060010190565b5f602082840312156146c5575f5ffd5b5051919050565b600181811c908216806146e057607f821691505b6020821081036121d957634e487b7160e01b5f52602260045260245ffd5b6001815b60018411156147395780850481111561471d5761471d6145b9565b600184161561472b57908102905b60019390931c928002614702565b935093915050565b5f8261474f5750600161086f565b8161475b57505f61086f565b8160018114614771576002811461477b57614797565b600191505061086f565b60ff84111561478c5761478c6145b9565b50506001821b61086f565b5060208310610133831016604e8410600b84101617156147ba575081810a61086f565b6147c65f1984846146fe565b805f19048211156147d9576147d96145b9565b029392505050565b5f611fa78383614741565b808202811582820484141761086f5761086f6145b9565b634e487b7160e01b5f52601260045260245ffd5b5f8261482557614825614803565b500490565b601f82111561067657805f5260205f20601f840160051c8101602085101561484f5750805b601f840160051c820191505b8181101561486e575f815560010161485b565b5050505050565b81516001600160401b0381111561488e5761488e613e8a565b6148a28161489c84546146cc565b8461482a565b6020601f8211600181146148d4575f83156148bd5750848201515b5f19600385901b1c1916600184901b17845561486e565b5f84815260208120601f198516915b8281101561490357878501518255602094850194600190920191016148e3565b508482101561492057868401515f19600387901b60f8161c191681555b50505050600190811b01905550565b828152604060208201525f611fa46040830184614244565b5f82518060208501845e5f920191825250919050565b5f6020828403121561496d575f5ffd5b8151611fa78161421b565b60ff828116828216039081111561086f5761086f6145b9565b5f611fa760ff841683614741565b5f826149ad576149ad614803565b600160ff1b82145f19841416156149c6576149c66145b9565b500590565b8082018281125f8312801582168215821617156149ea576149ea6145b9565b505092915050565b8082025f8212600160ff1b84141615614a0d57614a0d6145b9565b818105831482151761086f5761086f6145b956fef3177357ab46d8af007ab3fdb9af81da189e1068fefdc0073dca88a2cab40a00a16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d100cd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300a264697066735822122071496504e1eae5813f7f820f0dd0e14ee6c2cae1e223f0b7de204e7c1f2fea8964736f6c634300081c0033",
+    "sourceMap": "1475:22459:116:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5021:514;;;;;;:::i;:::-;;:::i;:::-;;;;;;;;:::i;:::-;;;;;;;;4086:97;4163:13;;4086:97;;;1869:25:126;;;1857:2;1842:18;4086:97:116;1723:177:126;4432:545:116;;;;;;:::i;:::-;;:::i;2040:50::-;;2086:4;2040:50;;6250:175;;;;;;:::i;:::-;;:::i;:::-;;3831:66;;;:::i;3468:289::-;;;;;;:::i;:::-;;:::i;3927:115::-;;;:::i;:::-;;;-1:-1:-1;;;;;3055:32:126;;;3037:51;;3025:2;3010:18;3927:115:116;2891:203:126;7933:637:116;;;;;;:::i;:::-;;:::i;2496:145:62:-;-1:-1:-1;;;;;;;;;;;2625:9:62;;;2496:145;;;9061:14:126;;9054:22;9036:41;;9024:2;9009:18;2496:145:62;8896:187:126;4227:161:116;;;;;;:::i;:::-;;:::i;6469:623::-;;;;;;:::i;:::-;;:::i;5579:159::-;;;;;;:::i;:::-;;:::i;310:40:117:-;;;;;;:::i;:::-;;;;;;;;;;;;;;;5782:424:116;;;;;;:::i;:::-;;:::i;515:213:117:-;;;;;;:::i;:::-;;:::i;4069:362:55:-;;;;;;:::i;:::-;;:::i;2353:23:116:-;;;;;-1:-1:-1;;;;;2353:23:116;;;3763:62;;;:::i;5048:903:64:-;;;:::i;:::-;;;;;;;;;;;;;:::i;7136:314:116:-;;;;;;:::i;:::-;;:::i;:::-;;;;;;;;;;:::i;7494:395::-;;;;;;:::i;:::-;;:::i;4472:227:55:-;;;:::i;:::-;;;-1:-1:-1;;;;;;15240:33:126;;;15222:52;;15210:2;15195:18;4472:227:55;15078:202:126;3864:164:55;;;:::i;2886:337:116:-;;;;;;:::i;:::-;;:::i;3292:132::-;;;;;;:::i;:::-;;:::i;416:66:117:-;;;:::i;761:147::-;;;;;;:::i;:::-;-1:-1:-1;;;;;868:19:117;;;;845:4;868:19;;;;;;;;;;;:33;;761:147;2326:21:116;;;;;-1:-1:-1;;;;;2326:21:116;;;5021:514;5123:27;5152:30;5228:29;5245:11;;5228:16;:29::i;:::-;5198:59;;-1:-1:-1;5198:59:116;-1:-1:-1;5272:9:116;5267:262;5291:10;:17;5287:1;:21;5267:262;;;1876:1;-1:-1:-1;;;;;5333:38:116;:10;5344:1;5333:13;;;;;;;;:::i;:::-;;;;;;;:38;5329:116;;5415:11;;5427:1;5415:14;;;;;;;:::i;:::-;;;;;;;5398:32;;-1:-1:-1;;;5398:32:116;;;;;;1869:25:126;;1857:2;1842:18;;1723:177;5398:32:116;;;;;;;;5329:116;5503:1;5486:10;5497:1;5486:13;;;;;;;;:::i;:::-;;;;;;;;;;:18;;;;;;;;5310:3;;5267:262;;;;5021:514;;;;;:::o;4432:545::-;4535:30;;4627:11;;-1:-1:-1;;;;;4671:18:116;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;4671:18:116;;4655:34;;4729:3;-1:-1:-1;;;;;4715:18:116;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;4715:18:116;-1:-1:-1;4699:34:116;-1:-1:-1;4749:9:116;4744:227;4768:3;4764:1;:7;4744:227;;;4792:43;4838:14;:30;4853:11;;4865:1;4853:14;;;;;;;:::i;:::-;;;;;;;;;;4838:30;;-1:-1:-1;4838:30:116;;;;;;;;;;;-1:-1:-1;4838:30:116;4792:76;;;;;;;;;-1:-1:-1;;;;;4792:76:116;;;;;;-1:-1:-1;;;4792:76:116;;;;;;;;;;4883:16;;4792:76;;-1:-1:-1;4792:76:116;;4883:13;;4897:1;;4883:16;;;;;;:::i;:::-;;;;;;4901:13;4915:1;4901:16;;;;;;;;:::i;:::-;;;;;;;;;;4882:78;;;;;-1:-1:-1;4773:3:116;;4744:227;;;;4603:374;4432:545;;;;;:::o;6250:175::-;1979:19:62;:17;:19::i;:::-;6335:9:116::1;6330:89;6346:17:::0;;::::1;6330:89;;;6384:24;6398:6;;6405:1;6398:9;;;;;;;:::i;:::-;;;;;;6384:13;:24::i;:::-;6365:3;;6330:89;;;;6250:175:::0;;:::o;3831:66::-;3766:39:55;966:10:60;3780:12:55;1040:14:60;;3766:13:55;:39::i;:::-;3880:10:116::1;:8;:10::i;:::-;3831:66::o:0;3468:289::-;3766:39:55;966:10:60;3780:12:55;887:96:60;3766:39:55;2086:4:116::1;3552:14;:36;3548:98;;;3611:24;;-1:-1:-1::0;;;3611:24:116::1;;;;;;;;;;;3548:98;3680:13;::::0;3660:50:::1;::::0;;16497:25:126;;;16553:2;16538:18;;16531:34;;;3660:50:116::1;::::0;16470:18:126;3660:50:116::1;;;;;;;3720:13;:30:::0;3468:289::o;3927:115::-;4008:8;;3998:37;;;-1:-1:-1;;;3998:37:116;;;;3972:7;;-1:-1:-1;;;;;4008:8:116;;3998:35;;:37;;;;;;;;;;;;;;4008:8;3998:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;3991:44;;3927:115;:::o;7933:637::-;2530:13;:11;:13::i;:::-;1979:19:62::1;:17;:19::i;:::-;8095:23:116::2;8132:4;8121:27;;;;;;;;;;;;:::i;:::-;8095:53;;8160:37;8199:18;8219:19;8240:17;8273:38;8304:6;8273:30;:38::i;:::-;8159:152;;;;;;;;8322:41;8338:6;8346:16;8322:15;:41::i;:::-;8374:83;8394:6;8401:1;8394:9;;;;;;;;:::i;:::-;;;;;;;:15;;;:18;;;8414:6;8421:1;8414:9;;;;;;;;:::i;:::-;;;;;;;:15;;;:25;;;8441:15;8374:19;:83::i;:::-;8468:95;8492:8;8502:6;8510:16;8528:10;8540:11;8553:9;8468:23;:95::i;:::-;8085:485;;;;;7933:637:::0;;;:::o;4227:161::-;4287:7;4313:68;2145:174;4373:5;4340:39;;;;;;;;;:::i;:::-;;;;;;;;;;;;;4330:50;;;;;;4313:16;:68::i;:::-;4306:75;4227:161;-1:-1:-1;;4227:161:116:o;6469:623::-;1979:19:62;:17;:19::i;:::-;6564:10:116::1;6549:11;::::0;;;::::1;::::0;::::1;;:::i;:::-;-1:-1:-1::0;;;;;6549:25:116::1;;6545:73;;6597:10;;-1:-1:-1::0;;;6597:10:116::1;;;;;;;;;;;6545:73;6631:18;::::0;::::1;;:23:::0;;:66:::1;;-1:-1:-1::0;6659:38:116::1;;;::::0;;::::1;::::0;::::1;6691:5:::0;6659:38:::1;:::i;:::-;:31;:38::i;:::-;6658:39;6631:66;6627:128;;;6720:24;;-1:-1:-1::0;;;6720:24:116::1;;;;;;;;;;;6627:128;6765:17;6785:16;;;::::0;;::::1;::::0;::::1;6795:5:::0;6785:16:::1;:::i;:::-;1876:1;6815:25:::0;;;:14:::1;:25;::::0;;;;:35;6765:36;;-1:-1:-1;;;;;;6815:35:116::1;:60:::0;6811:131:::1;;6898:33;::::0;-1:-1:-1;;;6898:33:116;;::::1;::::0;::::1;1869:25:126::0;;;1842:18;;6898:33:116::1;1723:177:126::0;6811:131:116::1;6990:42;7009:22;:18;::::0;::::1;;7030:1;7009:22;:::i;:::-;6990:18;:42::i;:::-;6952:25;::::0;;;:14:::1;:25;::::0;;;;;:80;;-1:-1:-1;;;;;;6952:80:116::1;-1:-1:-1::0;;;;;6952:80:116;;;::::1;::::0;;;::::1;::::0;;;7048:37;;7074:10:::1;::::0;6952:25;;7048:37:::1;::::0;6952:25;7048:37:::1;6535:557;6469:623:::0;:::o;5579:159::-;5649:9;5644:88;5660:17;;;5644:88;;;5698:23;5711:6;;5718:1;5711:9;;;;;;;:::i;:::-;;;;;;5698:12;:23::i;:::-;5679:3;;5644:88;;5782:424;5862:10;5847:11;;;;;;;;:::i;:::-;-1:-1:-1;;;;;5847:25:116;;5843:73;;5895:10;;-1:-1:-1;;;5895:10:116;;;;;;;;;;;5843:73;5926:17;5946:16;;;;;;;;5956:5;5946:16;:::i;:::-;5976:25;;;;:14;:25;;;;;:35;:25;;-1:-1:-1;;;;;;5976:35:116;-1:-1:-1;;5976:52:116;5972:114;;6051:24;;-1:-1:-1;;;6051:24:116;;;;;1869:25:126;;;1842:18;;6051:24:116;1723:177:126;5972:114:116;6096:25;;;;:14;:25;;;;;;;;;:51;;-1:-1:-1;;;;;;6096:51:116;1925:1;6096:51;;;6163:36;;6177:10;18827:51:126;;18894:18;;;18887:34;;;6163:36:116;;18800:18:126;6163:36:116;;;;;;;;5833:373;5782:424;:::o;515:213:117:-;593:10;568:16;587:17;;;;;;;;;;;:26;;;;;;;:::i;:::-;629:10;623:5;:17;;;;;;;;;;:28;;;568:45;;-1:-1:-1;666:55:117;693:17;;;;568:45;693:17;:::i;:::-;666:55;;;16497:25:126;;;16553:2;16538:18;;16531:34;;;16470:18;666:55:117;;;;;;;558:170;515:213;:::o;4069:362:55:-;966:10:60;4191:11:55;:9;:11::i;:::-;-1:-1:-1;;;;;4181:21:55;:6;-1:-1:-1;;;;;4181:21:55;;4177:92;;4225:33;;-1:-1:-1;;;4225:33:55;;-1:-1:-1;;;;;3055:32:126;;4225:33:55;;;3037:51:126;3010:18;;4225:33:55;2891:203:126;4177:92:55;4282:12;-1:-1:-1;;;;;4282:24:55;;4310:1;4282:29;4278:110;;4334:43;;-1:-1:-1;;;4334:43:55;;-1:-1:-1;;;;;3055:32:126;;4334:43:55;;;3037:51:126;3010:18;;4334:43:55;2891:203:126;4278:110:55;4397:27;4411:12;4397:13;:27::i;:::-;4128:303;4069:362;:::o;3763:62:116:-;3766:39:55;966:10:60;3780:12:55;887:96:60;3766:39:55;3810:8:116::1;:6;:8::i;5048:903:64:-:0;5146:13;5173:18;;5146:13;;;5173:18;5146:13;-1:-1:-1;;;;;;;;;;;5652:13:64;;5386:45;;-1:-1:-1;5652:18:64;:43;;;;-1:-1:-1;5674:16:64;;;;:21;5652:43;5644:77;;;;-1:-1:-1;;;5644:77:64;;19267:2:126;5644:77:64;;;19249:21:126;19306:2;19286:18;;;19279:30;-1:-1:-1;;;19325:18:126;;;19318:51;19386:18;;5644:77:64;19065:345:126;5644:77:64;5783:13;:11;:13::i;:::-;5810:16;:14;:16::i;:::-;5918;;;5902:1;5918:16;;;;;;;;;-1:-1:-1;;;5732:212:64;;;-1:-1:-1;5732:212:64;;-1:-1:-1;5840:13:64;;-1:-1:-1;5875:4:64;;-1:-1:-1;5902:1:64;-1:-1:-1;5918:16:64;-1:-1:-1;5732:212:64;-1:-1:-1;;5048:903:64:o;7136:314:116:-;7285:37;7324:18;7344:19;7365:17;2530:13;:11;:13::i;:::-;1979:19:62::1;:17;:19::i;:::-;7405:38:116::2;;7436:6:::0;;7405:38:::2;:::i;:::-;:30;:38::i;:::-;7398:45:::0;;;;-1:-1:-1;7398:45:116;-1:-1:-1;7398:45:116;;-1:-1:-1;7136:314:116;-1:-1:-1;;;7136:314:116:o;7494:395::-;2530:13;:11;:13::i;:::-;1979:19:62::1;:17;:19::i;:::-;3395:21:63::2;:19;:21::i;:::-;7787:95:116::3;7811:8;7821:6;7829:16;7847:10;7859:11;7872:9;7787:23;:95::i;:::-;3437:20:63::2;1949:1:::0;2532:30;4113:23;3860:283;3437:20:::2;7494:395:116::0;;;;;;:::o;4472:227:55:-;-1:-1:-1;;;;;;;;;;;4621:20:55;;4527:6;;1738:28;-1:-1:-1;;;4621:20:55;;;;:71;;4690:1;4621:71;;;-1:-1:-1;;;4621:71:55;4614:78;;;4472:227;:::o;3864:164::-;-1:-1:-1;;;;;;;;;;;4009:12:55;-1:-1:-1;;;;;4009:12:55;;3864:164::o;2886:337:116:-;4158:30:56;4191:26;:24;:26::i;:::-;4302:15;;4158:59;;-1:-1:-1;4302:15:56;-1:-1:-1;;;4302:15:56;;;4301:16;;-1:-1:-1;;;;;4348:14:56;4279:19;4724:16;;:34;;;;;4744:14;4724:34;4704:54;;4768:17;4788:11;-1:-1:-1;;;;;4788:16:56;4803:1;4788:16;:50;;;;-1:-1:-1;4816:4:56;4808:25;:30;4788:50;4768:70;;4854:12;4853:13;:30;;;;;4871:12;4870:13;4853:30;4849:91;;;4906:23;;-1:-1:-1;;;4906:23:56;;;;;;;;;;;4849:91;4949:18;;-1:-1:-1;;4949:18:56;4966:1;4949:18;;;4977:67;;;;5011:22;;-1:-1:-1;;;;5011:22:56;-1:-1:-1;;;5011:22:56;;;4977:67;3000:39:116::1;3021:17;3000:20;:39::i;:::-;3049:50;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;;-1:-1:-1::0;;;3049:50:116::1;;::::0;:13:::1;:50::i;:::-;3109:17;:15;:17::i;:::-;3136:24;:22;:24::i;:::-;3170:8;:20:::0;;-1:-1:-1;;;;;3170:20:116;;::::1;-1:-1:-1::0;;;;;;3170:20:116;;::::1;;::::0;;;3200:6:::1;:16:::0;;;;::::1;::::0;;;::::1;::::0;;;::::1;::::0;;5064:101:56;;;;5098:23;;-1:-1:-1;;;;5098:23:56;;;5140:14;;-1:-1:-1;19893:50:126;;5140:14:56;;19881:2:126;19866:18;5140:14:56;;;;;;;4092:1079;;;;;2886:337:116;;;:::o;3292:132::-;3766:39:55;966:10:60;3780:12:55;887:96:60;3766:39:55;3360:6:116::1;:18:::0;;-1:-1:-1;;;;;;3360:18:116::1;-1:-1:-1::0;;;;;3360:18:116;::::1;::::0;;::::1;::::0;;;3393:24:::1;::::0;::::1;::::0;-1:-1:-1;;3393:24:116::1;3292:132:::0;:::o;416:66:117:-;460:15;473:1;460:12;:15::i;2709:128:62:-;-1:-1:-1;;;;;;;;;;;2625:9:62;;;2770:61;;;2805:15;;-1:-1:-1;;;2805:15:62;;;;;;;;;;;5282:667:55;-1:-1:-1;;;;;;;;;;;5369:30:55;;5471:144;5516:11;:9;:11::i;:::-;5541:6;5569:4;5595:9;5602:1;5600;5595:4;;:9;:::i;:::-;5588:17;;;:::i;:::-;5471:31;:144::i;:::-;5438:177;;;;5630:9;5625:318;;5659:9;;;;5655:278;;5688:27;;-1:-1:-1;;;;5688:27:55;-1:-1:-1;;;5688:27:55;;;5748:11;:9;:11::i;:::-;-1:-1:-1;;;;;5733:46:55;;5780:6;5788:4;;5733:60;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;5811:28:55;;-1:-1:-1;;;;5811:28:55;;;-1:-1:-1;5655:278:55;;-1:-1:-1;5655:278:55;;5885:33;;-1:-1:-1;;;5885:33:55;;-1:-1:-1;;;;;3055:32:126;;5885:33:55;;;3037:51:126;3010:18;;5885:33:55;2891:203:126;3478:178:62;2226:16;:14;:16::i;:::-;-1:-1:-1;;;;;;;;;;;3595:17:62;;-1:-1:-1;;3595:17:62::1;::::0;;3627:22:::1;966:10:60::0;3636:12:62::1;3627:22;::::0;-1:-1:-1;;;;;3055:32:126;;;3037:51;;3025:2;3010:18;3627:22:62::1;;;;;;;3526:130;3478:178::o:0;2620:122:116:-;2685:6;;-1:-1:-1;;;;;2685:6:116;2671:10;:20;2667:69;;2714:11;;-1:-1:-1;;;2714:11:116;;;;;;;;;;;9193:3448;9299:37;9338:18;9358:19;9379:17;9412:15;9437:44;9484:6;9491:1;9484:9;;;;;;;;:::i;:::-;;;;;;;:15;;;:25;;;9437:72;;9556:6;:13;-1:-1:-1;;;;;9538:32:116;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;;;;;;;;;;;;;9538:32:116;;;;;;;;;;;;;;;;9519:51;;9585:9;9580:2969;9600:6;:13;9596:1;:17;9580:2969;;;9634:36;9673:6;9680:1;9673:9;;;;;;;;:::i;:::-;;;;;;;:15;;;9634:54;;9815:63;9834:6;9841:1;9834:9;;;;;;;;:::i;:::-;;;;;;;:15;;;:18;;;9854:16;9872:5;9815:18;:63::i;:::-;9810:134;;9905:24;;-1:-1:-1;;;;;;9905:24:116;;;;;;;;;;;9810:134;9962:38;9994:5;9962:31;:38::i;:::-;9957:113;;10020:9;;;:::i;:::-;;;10047:8;;;9957:113;10084:17;10104:16;10114:5;10104:9;:16::i;:::-;10134:11;10148:25;;;:14;:25;;;;;:35;:25;;-1:-1:-1;;;;;;10148:35:116;;;:60;;;;10134:11;10502:860;;10532:11;10546:25;;;:14;:25;;;;;:35;-1:-1:-1;;;;;10546:35:116;1925:1;10546:52;10616:92;;;;10650:9;;;:::i;:::-;;;10681:8;;;;;;;10616:92;-1:-1:-1;;10829:25:116;;;;:14;:25;;;;;:35;-1:-1:-1;;;;;10829:35:116;-1:-1:-1;;10914:25:116;10502:860;;;11048:19;11070:38;11087:6;11094:1;11087:9;;;;;;;;:::i;:::-;;;;;;;11098;11070:16;:38::i;:::-;11048:60;;11131:14;11126:101;;11169:9;;;:::i;11126:101::-;-1:-1:-1;;11329:18:116;;;;10502:860;11432:17;11452:54;11461:20;11483:6;11490:1;11483:9;;;;;;;;:::i;:::-;;;;;;;:22;;;11452:8;:54::i;:::-;11432:74;;11594:9;11571:20;:32;11548:55;;11649:214;;;;;;;;11694:44;11713:20;11736:1;11713:24;11694:18;:44::i;:::-;-1:-1:-1;;;;;11649:214:116;;;;;11793:25;;;;:14;11649:214;11793:25;;;;;;;:38;11649:214;;;11774:70;;-1:-1:-1;;;11793:38:116;;;;:50;;11774:18;:70::i;:::-;-1:-1:-1;;;;;11649:214:116;;;;;;11621:25;;;;:14;:25;;;;;;;;:242;;;;;;;;-1:-1:-1;;;11621:242:116;;;;;;;;;;;;-1:-1:-1;;;;;;;;;;;;;;;11991:40:116;12014:5;12021:9;11991:22;:40::i;:::-;11969:18;;;11940:91;;;12099:9;;:6;;12106:1;;12099:9;;;;;;:::i;:::-;;;;;;;:19;;;12078:13;:18;;;12049:13;:26;;;:47;;;;:::i;:::-;:69;12045:134;;;12145:19;;-1:-1:-1;;;12145:19:116;;;;;;;;;;;12045:134;12237:18;;;;12208:26;;:47;;12237:18;12208:47;:::i;:::-;12193:62;;;;:::i;:::-;;;12282:13;:18;;;12269:31;;;;;:::i;:::-;;;12336:80;;;;;;;;12363:13;:26;;;12336:80;;;;12405:9;12336:80;;;12314:16;12331:1;12314:19;;;;;;;;:::i;:::-;;;;;;;;;;:102;-1:-1:-1;;;;;12434:26:116;;12430:109;;12493:31;12508:6;12515:1;12508:9;;;;;;;;:::i;:::-;;;;;;;:15;;;12493:14;:31::i;:::-;12480:44;;12430:109;9620:2929;;;;;;9580:2969;9615:3;;9580:2969;;;;12574:6;:13;12563:7;:24;12559:76;;12610:14;;-1:-1:-1;;;12610:14:116;;;;;;;;;;;12559:76;9402:3239;;9193:3448;;;;;:::o;14286:436::-;14407:9;14402:314;14422:16;:23;14418:1;:27;14402:314;;;14470:16;14487:1;14470:19;;;;;;;;:::i;:::-;;;;;;;:32;;;14506:1;14470:37;14466:51;14509:8;14466:51;14531:18;14552:32;14568:6;14575:1;14568:9;;;;;;;;:::i;:::-;;;;;;;:15;;;14552;:32::i;:::-;14531:53;;14598:107;14634:6;14641:1;14634:9;;;;;;;;:::i;:::-;;;;;;;:15;;;:21;;;14665:4;14672:16;14689:1;14672:19;;;;;;;;:::i;:::-;;;;;;;:32;;;14605:10;-1:-1:-1;;;;;14598:35:116;;;:107;;;;;;:::i;:::-;14452:264;14402:314;14447:3;;14402:314;;15800:1195;15906:19;15944:2;15906:41;;15957:11;15971:3;-1:-1:-1;;;;;15971:10:116;;:12;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;15957:26;;15993:10;16006:3;-1:-1:-1;;;;;16006:9:116;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;15993:24;;16051:3;-1:-1:-1;;;;;16032:22:116;:15;-1:-1:-1;;;;;16032:22:116;;:98;;;;-1:-1:-1;16072:20:116;16059:9;:33;;;;;;;;:::i;:::-;;:70;;;-1:-1:-1;16109:20:116;16096:9;:33;;;;;;;;:::i;:::-;;16059:70;16028:961;;;16167:36;;-1:-1:-1;;;16167:36:116;;16197:4;16167:36;;;3037:51:126;16146:18:116;;-1:-1:-1;;;;;16167:21:116;;;;;3010:18:126;;16167:36:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;16146:57;-1:-1:-1;16221:14:116;;16217:176;;16255:49;-1:-1:-1;;;;;16255:33:116;;16289:2;16293:10;16255:33;:49::i;:::-;16322:56;;-1:-1:-1;;;16322:56:116;;;;;21654:25:126;;;16357:4:116;21695:18:126;;;21688:60;;;21764:18;;;21757:60;-1:-1:-1;;;;;16322:14:116;;;;;21627:18:126;;16322:56:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;16217:176;16132:271;16028:961;;;16446:2;-1:-1:-1;;;;;16427:21:116;:15;-1:-1:-1;;;;;16427:21:116;;:58;;;;-1:-1:-1;16465:20:116;16452:9;:33;;;;;;;;:::i;:::-;;16427:58;16426:140;;;;16526:2;-1:-1:-1;;;;;16507:21:116;:15;-1:-1:-1;;;;;16507:21:116;;:58;;;;-1:-1:-1;16545:20:116;16532:9;:33;;;;;;;;:::i;:::-;;16507:58;16409:580;;;16611:35;;-1:-1:-1;;;16611:35:116;;16640:4;16611:35;;;3037:51:126;16591:17:116;;-1:-1:-1;;;;;16611:20:116;;;;;3010:18:126;;16611:35:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;16680;;-1:-1:-1;;;16680:35:116;;16709:4;16680:35;;;3037:51:126;16591:55:116;;-1:-1:-1;16660:17:116;;-1:-1:-1;;;;;16680:20:116;;;;;3010:18:126;;16680:35:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;16660:55;;16729:20;16752:30;16761:9;16772;16752:8;:30::i;:::-;16729:53;-1:-1:-1;16800:16:116;;16796:183;;16836:50;-1:-1:-1;;;;;16836:32:116;;16869:2;16873:12;16836:32;:50::i;:::-;16904:60;;-1:-1:-1;;;16904:60:116;;;;;21654:25:126;;;16943:4:116;21695:18:126;;;21688:60;;;21764:18;;;21757:60;-1:-1:-1;;;;;16904:16:116;;;;;21627:18:126;;16904:60:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;16796:183;16577:412;;;15896:1099;;;15800:1195;;;:::o;13264:824::-;13523:13;;:18;;:62;;;13562:16;:23;13545:6;:13;:40;;13523:62;13519:120;;;13608:20;;-1:-1:-1;;;13608:20:116;;;;;;;;;;;13519:120;-1:-1:-1;;;;;13652:22:116;;;;:50;;-1:-1:-1;;;;;;13678:24:116;;;13652:50;13648:83;;;13711:20;;-1:-1:-1;;;13711:20:116;;;;;;;;;;;13648:83;13745:43;;-1:-1:-1;;;13745:43:116;;13782:4;13745:43;;;3037:51:126;13791:11:116;;-1:-1:-1;;;;;13745:28:116;;;;;3010:18:126;;13745:43:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:57;13741:114;;;13825:19;;-1:-1:-1;;;13825:19:116;;;;;;;;;;;13741:114;13865:51;13879:6;13887:16;13905:10;13865:13;:51::i;:::-;13931:13;;13927:102;;13960:58;13992:14;:12;:14::i;:::-;-1:-1:-1;;;;;13960:31:116;;;14008:9;13960:31;:58::i;:::-;14039:42;14052:8;14062:6;14069:1;14062:9;;;;;;;;:::i;:::-;;;;;;;:15;;;:18;;;14039:12;:42::i;4837:176:64:-;4914:7;4940:66;4973:20;:18;:20::i;:::-;4995:10;4049:4:45;4043:11;-1:-1:-1;;;4067:23:45;;4119:4;4110:14;;4103:39;;;;4171:4;4162:14;;4155:34;4227:4;4212:20;;;3874:374;20043:821:116;20127:4;20254:15;20238:5;:12;;;:31;20234:74;;-1:-1:-1;20292:5:116;;20043:821;-1:-1:-1;20043:821:116:o;20234:74::-;20318:16;20353:5;:8;;;-1:-1:-1;;;;;20337:34:116;;:36;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;20318:55;;20473:15;20461:8;:27;20457:70;;-1:-1:-1;20511:5:116;;20043:821;-1:-1:-1;;20043:821:116:o;20457:70::-;20607:8;20592:5;:12;;;:23;20588:66;;;-1:-1:-1;20638:5:116;;20043:821;-1:-1:-1;;20043:821:116:o;20588:66::-;20731:11;;;;20744;;;;;-1:-1:-1;;;;;868:19:117;;;845:4;868:19;;;;;;;;;:33;20714:81:116;;-1:-1:-1;20779:5:116;;20043:821;-1:-1:-1;;20043:821:116:o;20714:81::-;-1:-1:-1;20853:4:116;;20043:821;-1:-1:-1;;20043:821:116:o;9264:218:49:-;9321:7;-1:-1:-1;;;;;9344:25:49;;9340:105;;;9392:42;;-1:-1:-1;;;9392:42:49;;9423:3;9392:42;;;22010:36:126;22062:18;;;22055:34;;;21983:18;;9392:42:49;21828:267:126;9340:105:49;-1:-1:-1;9469:5:49;9264:218::o;4887:220:55:-;-1:-1:-1;;;;;;;;;;;5028:27:55;;-1:-1:-1;;;;;;5028:27:55;-1:-1:-1;;;;;5028:27:55;;;;;;;5070:30;;3037:51:126;;;5070:30:55;;3025:2:126;3010:18;5070:30:55;2891:203:126;3170:176:62;1979:19;:17;:19::i;:::-;-1:-1:-1;;;;;;;;;;;3288:16:62;;-1:-1:-1;;3288:16:62::1;3300:4;3288:16;::::0;;3319:20:::1;966:10:60::0;3326:12:62::1;887:96:60::0;6175:155:64;6316:7;6309:14;;6229:13;;-1:-1:-1;;;;;;;;;;;2730:21:64;6309:14;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;6175:155;:::o;6557:161::-;6701:10;6694:17;;6614:13;;-1:-1:-1;;;;;;;;;;;2730:21:64;6694:17;;;:::i;3470:384:63:-;2532:30;3670:9;;-1:-1:-1;;3670:20:63;3666:88;;3713:30;;-1:-1:-1;;;3713:30:63;;;;;;;;;;;3666:88;1991:1;3828:19;;3470:384::o;3860:283::-;1949:1;2532:30;4113:23;3860:283::o;9071:205:56:-;9129:30;;3147:66;9186:27;8819:122;1876:147:55;6929:20:56;:18;:20::i;:::-;1968:48:55::1;1999:16;1968:30;:48::i;:::-;1876:147:::0;:::o;3337::64:-;6929:20:56;:18;:20::i;:::-;3439:38:64::1;3463:4;3469:7;3439:23;:38::i;2266:60:62:-:0;6929:20:56;:18;:20::i;2684:111:63:-;6929:20:56;:18;:20::i;:::-;2754:34:63::1;:32;:34::i;591:782:3:-:0;806:62;;-1:-1:-1;;;;;22703:32:126;;;806:62:3;;;22685:51:126;22772:32;;22752:18;;;22745:60;-1:-1:-1;;;;;;22841:33:126;;22821:18;;;22814:61;746:14:3;;;;;;22658:18:126;;806:62:3;;;-1:-1:-1;;806:62:3;;;;;;;;;;;;;;;-1:-1:-1;;;;;806:62:3;-1:-1:-1;;;806:62:3;;;-1:-1:-1;918:18:3;;;949;;;;1030:11;;806:62;;-1:-1:-1;806:62:3;;-1:-1:-1;;1002:9:3;995:5;984:70;981:376;;;1092:4;1086:11;1129:4;1123:11;;1086;;-1:-1:-1;1327:14:3;;;1320:22;1309:34;;-1:-1:-1;981:376:3;904:463;591:782;;;;;;;:::o;2909:126:62:-;-1:-1:-1;;;;;;;;;;;2625:9:62;;;2967:62;;3003:15;;-1:-1:-1;;;3003:15:62;;;;;;;;;;;19482:296:116;19673:12;19716:16;-1:-1:-1;;;;;19704:28:116;:5;:8;;;-1:-1:-1;;;;;19704:28:116;;:67;;;;;19755:16;19736:35;;;;;;;;:::i;:::-;:5;:15;;;:35;;;;;;;;:::i;:::-;;19704:67;19697:74;;19482:296;;;;;;:::o;18889:268::-;19029:12;19067:83;19104:5;:11;;;:17;;;19123:9;19134:5;:15;;;19067:36;:83::i;5617:111:48:-;5675:7;5312:5;;;5709;;;5311:36;5306:42;;5701:20;5071:294;21488:595:116;21606:20;21628:12;21656:37;21696:5;:15;;;21656:55;;21721:22;21746:13;;21721:38;;21769:17;21796:20;21867:89;21901:9;21912:5;:8;;;21922:5;:17;;;21941:14;21867:33;:89::i;:::-;21827:129;;-1:-1:-1;21827:129:116;-1:-1:-1;2015:19:116;1974:2;2015;:19;:::i;:::-;22004:9;21976:24;21991:9;21976:12;:24;:::i;:::-;21975:38;;;;:::i;:::-;21974:47;;;;:::i;:::-;21967:54;-1:-1:-1;2015:19:116;1974:2;2015;:19;:::i;:::-;22047:21;22059:9;22047;:21;:::i;:::-;22046:30;;;;:::i;:::-;22031:45;;21646:437;;;;21488:595;;;;;:::o;22338:695::-;22490:8;;;;22423:18;;22532:38;22513:5;:15;;;:57;;;;;;;;:::i;:::-;;22509:518;;22599:5;:8;;;22586:21;;22509:518;;;22647:38;22628:5;:15;;;:57;;;;;;;;:::i;:::-;;22624:403;;22714:2;-1:-1:-1;;;;;22714:9:116;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;22701:24;;22624:403;;;22765:38;22746:5;:15;;;:57;;;;;;;;:::i;:::-;;22742:285;;22832:2;-1:-1:-1;;;;;22832:8:116;;:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;22742:285;22882:38;22863:5;:15;;;:57;;;;;;;;:::i;:::-;;22859:168;;22949:2;-1:-1:-1;;;;;22949:9:116;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;22859:168;22998:18;;-1:-1:-1;;;22998:18:116;;;;;;;;;;;22859:168;22443:590;22338:695;;;:::o;23292:640::-;23445:8;;;;23378:18;;23487:38;23468:5;:15;;;:57;;;;;;;;:::i;:::-;;23464:462;;23554:2;-1:-1:-1;;;;;23554:9:116;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23464:462;23605:38;23586:5;:15;;;:57;;;;;;;;:::i;:::-;;23582:344;;23672:5;:8;;;23659:21;;23582:344;;;23720:38;23701:5;:15;;;:57;;;;;;;;:::i;:::-;;23697:229;;23787:2;-1:-1:-1;;;;;23787:9:116;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;23697:229;23838:38;23819:5;:15;;;:57;;;;;;;;:::i;:::-;;23815:111;;23905:2;-1:-1:-1;;;;;23905:8:116;;:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;1618:188:32:-;1745:53;;-1:-1:-1;;;;;24959:32:126;;;1745:53:32;;;24941:51:126;25028:32;;;25008:18;;;25001:60;25077:18;;;25070:34;;;1718:81:32;;1738:5;;1760:18;;;;;24914::126;;1745:53:32;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;1745:53:32;;;;;;;;;;;1718:19;:81::i;:::-;1618:188;;;;:::o;3146:225::-;3265:39;;-1:-1:-1;;;3265:39:32;;3289:4;3265:39;;;25289:51:126;-1:-1:-1;;;;;25376:32:126;;;25356:18;;;25349:60;3242:20:32;;3265:15;;;;;;25262:18:126;;3265:39:32;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;3242:62;-1:-1:-1;3314:50:32;3327:5;3334:7;3343:20;3358:5;3242:62;3343:20;:::i;:::-;3314:12;:50::i;17285:475:116:-;17436:9;17431:323;17451:16;:23;17447:1;:27;17431:323;;;17499:16;17516:1;17499:19;;;;;;;;:::i;:::-;;;;;;;:32;;;17535:1;17499:37;17495:51;17538:8;17495:51;17560:91;17592:6;17599:1;17592:9;;;;;;;;:::i;:::-;;;;;;;:15;;;:24;;;17618:16;17635:1;17618:19;;;;;;;;:::i;:::-;;;;;;;:32;;;17567:10;-1:-1:-1;;;;;17560:31:116;;;:91;;;;;:::i;:::-;17670:73;17682:26;17692:6;17699:1;17692:9;;;;;;;;:::i;:::-;;;;;;;:15;;;17682:9;:26::i;:::-;17710:16;17727:1;17710:19;;;;;;;;:::i;:::-;;;;;;;:32;;;17670:73;;;;;;16497:25:126;;;16553:2;16538:18;;16531:34;16485:2;16470:18;;16323:248;17670:73:116;;;;;;;;17431:323;17476:3;;17431:323;;1219:160:32;1328:43;;-1:-1:-1;;;;;18845:32:126;;;1328:43:32;;;18827:51:126;18894:18;;;18887:34;;;1301:71:32;;1321:5;;1343:14;;;;;18800:18:126;;1328:43:32;18653:274:126;17996:610:116;18067:19;18105:2;18067:41;;18118:11;18132:3;-1:-1:-1;;;;;18132:10:116;;:12;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;18118:26;;18154:10;18167:3;-1:-1:-1;;;;;18167:9:116;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;18210:36;;-1:-1:-1;;;18210:36:116;;18240:4;18210:36;;;3037:51:126;18154:24:116;;-1:-1:-1;18189:18:116;;-1:-1:-1;;;;;18210:21:116;;;;;3010:18:126;;18210:36:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;18276:35;;-1:-1:-1;;;18276:35:116;;18305:4;18276:35;;;3037:51:126;18189:57:116;;-1:-1:-1;18256:17:116;;-1:-1:-1;;;;;18276:20:116;;;;;3010:18:126;;18276:35:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;18341;;-1:-1:-1;;;18341:35:116;;18370:4;18341:35;;;3037:51:126;18256:55:116;;-1:-1:-1;18321:17:116;;-1:-1:-1;;;;;18341:20:116;;;;;3010:18:126;;18341:35:116;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;18321:55;-1:-1:-1;18391:14:116;;18387:66;;18407:46;-1:-1:-1;;;;;18407:24:116;;18432:8;18442:10;18407:24;:46::i;:::-;18467:13;;18463:63;;18482:44;-1:-1:-1;;;;;18482:23:116;;18506:8;18516:9;18482:23;:44::i;:::-;18540:13;;18536:63;;18555:44;-1:-1:-1;;;;;18555:23:116;;18579:8;18589:9;18555:23;:44::i;3906:109:64:-;3959:7;3985:23;:21;:23::i;7082:141:56:-;7149:17;:15;:17::i;:::-;7144:73;;7189:17;;-1:-1:-1;;;7189:17:56;;;;;;;;;;;2029:140:55;6929:20:56;:18;:20::i;:::-;2131:31:55::1;2145:16;2131:13;:31::i;3490:330:64:-:0;6929:20:56;:18;:20::i;:::-;-1:-1:-1;;;;;;;;;;;3657:7:64;:14:::1;3667:4:::0;3657:7;:14:::1;:::i;:::-;-1:-1:-1::0;3681:10:64::1;::::0;::::1;:20;3694:7:::0;3681:10;:20:::1;:::i;:::-;-1:-1:-1::0;3782:1:64::1;3766:17:::0;;;3793:16:::1;::::0;;::::1;:20:::0;-1:-1:-1;;3490:330:64:o;2801:183:63:-;6929:20:56;:18;:20::i;1499:429:46:-;1605:4;1625:6;-1:-1:-1;;;;;1625:18:46;;1647:1;1625:23;1621:301;;1665:17;1684:22;1712:33;1729:4;1735:9;1712:16;:33::i;:::-;-1:-1:-1;1664:81:46;;-1:-1:-1;1664:81:46;-1:-1:-1;1773:26:46;1766:3;:33;;;;;;;;:::i;:::-;;:56;;;;;1816:6;-1:-1:-1;;;;;1803:19:46;:9;-1:-1:-1;;;;;1803:19:46;;1766:56;1759:63;;;;;;1621:301;1860:51;1887:6;1895:4;1901:9;1860:26;:51::i;:::-;1853:58;;;;1590:2864:121;1777:17;1796:20;1828:19;1850:30;1865:14;1850;:30::i;:::-;1828:52;;1890:21;1914:32;1931:14;1914:16;:32::i;:::-;1890:56;;1956:22;2026:15;1997:14;-1:-1:-1;;;;;1981:40:121;;:42;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:60;;;;:::i;:::-;1956:85;-1:-1:-1;2069:38:121;2056:9;:51;;;;;;;;:::i;:::-;;2052:2396;;2283:11;439:8:122;2152:81:121;2190:11;2203:14;2219:13;2152:37;:81::i;:::-;:127;;;;:::i;:::-;2151:143;;;;:::i;:::-;2123:171;-1:-1:-1;2646:11:121;439:8:122;2340:256:121;439:8:122;2423:36:121;2445:14;439:8:122;2423:36:121;:::i;:::-;2408:52;;:11;:52;:::i;:::-;2407:76;;;;:::i;:::-;2513:14;2557:13;2340:37;:256::i;:::-;:302;;;;:::i;:::-;2339:318;;;;:::i;:::-;2308:349;;2052:2396;;;2691:38;2678:9;:51;;;;;;;;:::i;:::-;;2674:1774;;2811:81;2849:11;2862:14;2878:13;2811:37;:81::i;:::-;2758:33;2780:11;439:8:122;2758:33:121;:::i;:::-;2757:135;;;;:::i;:::-;2745:147;-1:-1:-1;2975:224:121;439:8:122;3050:36:121;3072:14;439:8:122;3050:36:121;:::i;:::-;3035:52;;:11;:52;:::i;:::-;3034:76;;;;:::i;:::-;3132:14;3168:13;2975:37;:224::i;:::-;2922:33;2944:11;439:8:122;2922:33:121;:::i;2674:1774::-;3233:38;3220:9;:51;;;;;;;;:::i;:::-;;3216:1232;;3447:11;439:8:122;3316:81:121;3354:11;3367:14;3383:13;3316:37;:81::i;:::-;:127;;;;:::i;:::-;3315:143;;;;:::i;:::-;3287:171;-1:-1:-1;3810:11:121;439:8:122;3504:256:121;439:8:122;3587:36:121;3609:14;439:8:122;3587:36:121;:::i;:::-;3572:52;;:11;:52;:::i;:::-;3571:76;;;;:::i;:::-;3677:14;3721:13;3504:37;:256::i;3216:1232::-;3855:38;3842:9;:51;;;;;;;;:::i;:::-;;3838:610;;3975:81;4013:11;4026:14;4042:13;3975:37;:81::i;:::-;3922:33;3944:11;439:8:122;3922:33:121;:::i;:::-;3921:135;;;;:::i;:::-;3909:147;-1:-1:-1;4139:224:121;439:8:122;4214:36:121;4236:14;439:8:122;4214:36:121;:::i;:::-;4199:52;;:11;:52;:::i;:::-;4198:76;;;;:::i;:::-;4296:14;4332:13;4139:37;:224::i;3838:610::-;1818:2636;;;1590:2864;;;;;;;:::o;8370:720:32:-;8450:18;8478:19;8616:4;8613:1;8606:4;8600:11;8593:4;8587;8583:15;8580:1;8573:5;8566;8561:60;8673:7;8663:176;;8717:4;8711:11;8762:16;8759:1;8754:3;8739:40;8808:16;8803:3;8796:29;8663:176;-1:-1:-1;;8916:1:32;8910:8;8866:16;;-1:-1:-1;8942:15:32;;:68;;8994:11;9009:1;8994:16;;8942:68;;;-1:-1:-1;;;;;8960:26:32;;;:31;8942:68;8938:146;;;9033:40;;-1:-1:-1;;;9033:40:32;;-1:-1:-1;;;;;3055:32:126;;9033:40:32;;;3037:51:126;3010:18;;9033:40:32;2891:203:126;5084:380:32;5199:47;;;-1:-1:-1;;;;;18845:32:126;;5199:47:32;;;18827:51:126;18894:18;;;;18887:34;;;5199:47:32;;;;;;;;;;18800:18:126;;;;5199:47:32;;;;;;;;-1:-1:-1;;;;;5199:47:32;-1:-1:-1;;;5199:47:32;;;5262:44;5214:13;5199:47;5262:23;:44::i;:::-;5257:201;;5349:43;;-1:-1:-1;;;;;18845:32:126;;;5349:43:32;;;18827:51:126;5389:1:32;18894:18:126;;;18887:34;5322:71:32;;5342:5;;5364:13;;;;;18800:18:126;;5349:43:32;18653:274:126;5322:71:32;5407:40;5427:5;5434:12;5407:19;:40::i;4021:191:64:-;4076:7;1964:95;4134:17;:15;:17::i;:::-;4153:20;:18;:20::i;:::-;4112:92;;;;;;28622:25:126;;;;28663:18;;28656:34;;;;28706:18;;;28699:34;4175:13:64;28749:18:126;;;28742:34;4198:4:64;28792:19:126;;;28785:61;28594:19;;4112:92:64;;;;;;;;;;;;4102:103;;;;;;4095:110;;4021:191;:::o;8485:120:56:-;8535:4;8558:26;:24;:26::i;:::-;:40;-1:-1:-1;;;8558:40:56;;;;;;-1:-1:-1;8485:120:56:o;2129:778:44:-;2232:17;2251:16;2269:14;2299:9;:16;2319:2;2299:22;2295:606;;2604:4;2589:20;;2583:27;2653:4;2638:20;;2632:27;2710:4;2695:20;;2689:27;2337:9;2681:36;2751:25;2762:4;2681:36;2583:27;2632;2751:10;:25::i;:::-;2744:32;;;;;;;;;;;2295:606;-1:-1:-1;;2872:16:44;;2823:1;;-1:-1:-1;2827:35:44;;2295:606;2129:778;;;;;:::o;2335:458:46:-;2478:4;2495:12;2509:19;2532:6;-1:-1:-1;;;;;2532:17:46;2606:4;2612:9;2563:60;;;;;;;;;:::i;:::-;;;;-1:-1:-1;;2563:60:46;;;;;;;;;;;;;;-1:-1:-1;;;;;2563:60:46;-1:-1:-1;;;2563:60:46;;;2532:101;;;2563:60;2532:101;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2494:139;;;;2651:7;:42;;;;;2691:2;2674:6;:13;:19;;2651:42;:134;;;;-1:-1:-1;2709:29:46;;-1:-1:-1;;;2750:34:46;2709:29;;;;;;;;;;;;:::i;:::-;:76;2651:134;2643:143;2335:458;-1:-1:-1;;;;;;2335:458:46:o;5322:186:121:-;5393:7;5419:82;398:2:122;5419:82:121;;5435:14;-1:-1:-1;;;;;5419:42:121;;:44;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:52;;:82::i;4671:462::-;4744:7;4763:17;4814:14;-1:-1:-1;;;;;4798:38:121;;:40;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;-1:-1:-1;;;;;4783:65:121;;:67;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;4763:87;;4860:24;4927:14;-1:-1:-1;;;;;4911:38:121;;:40;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;-1:-1:-1;;;;;4902:56:121;;:58;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;-1:-1:-1;;;;;4887:83:121;;:85;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;4860:112;-1:-1:-1;5093:32:121;4860:112;5093:11;:32;:::i;:::-;5074:52;;:2;:52;:::i;:::-;-1:-1:-1;;;;;4990:45:121;;;5036:34;398:2:122;5036::121;:34;:::i;:::-;4990:81;;;;;;;;;;;;;1869:25:126;;1857:2;1842:18;;1723:177;4990:81:121;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:136;;;;:::i;:::-;4983:143;4671:462;-1:-1:-1;;;;4671:462:121:o;1160:863:122:-;1307:7;;496:8;1406:21;439:8;1406:14;:21;:::i;:::-;1399:48;;;;:::i;:::-;1388:59;-1:-1:-1;439:8:122;1515:14;1626:29;1643:11;439:8;1626:29;:::i;:::-;1612:43;;1665:20;1688:19;1702:4;1688:13;:19::i;:::-;1665:42;-1:-1:-1;1717:18:122;1738:45;1775:7;1754:17;1770:1;1665:42;1754:17;:::i;:::-;1753:29;;;;:::i;:::-;1738:14;:45::i;:::-;1717:66;-1:-1:-1;1851:19:122;1717:66;1874:31;1898:7;1881:13;1874:31;:::i;:::-;1873:47;;;;:::i;:::-;1851:69;1160:863;-1:-1:-1;;;;;;;;;;1160:863:122:o;2678:408::-;2825:7;2931:27;2961:66;2984:11;2997:14;3013:13;2961:22;:66::i;:::-;2931:96;-1:-1:-1;3044:35:122;2931:96;3044:13;:35;:::i;:::-;3037:42;2678:408;-1:-1:-1;;;;;2678:408:122:o;9592:480:32:-;9675:4;9691:12;9713:18;9741:19;9875:4;9872:1;9865:4;9859:11;9852:4;9846;9842:15;9839:1;9832:5;9825;9820:60;9809:71;;9907:16;9893:30;;9957:1;9951:8;9936:23;;9985:7;:80;;;;-1:-1:-1;9997:15:32;;:67;;10048:11;10063:1;10048:16;9997:67;;;-1:-1:-1;;;;;;;;;;10015:26:32;;:30;;;9592:480::o;6933:687:64:-;6983:7;-1:-1:-1;;;;;;;;;;;6983:7:64;7078:13;:11;:13::i;:::-;7105:18;;7057:34;;-1:-1:-1;7105:22:64;7101:513;;7150:22;;;;;;;;6933:687;-1:-1:-1;;6933:687:64:o;7101:513::-;7447:13;;7478:15;;7474:130;;7520:10;6933:687;-1:-1:-1;;;6933:687:64:o;7474:130::-;7576:13;7569:20;;;;;6933:687;:::o;7841:723::-;7894:7;-1:-1:-1;;;;;;;;;;;7894:7:64;7992:16;:14;:16::i;:::-;8022:21;;7968:40;;-1:-1:-1;8022:25:64;8018:540;;8070:25;;;;;;;;7841:723;-1:-1:-1;;7841:723:64:o;8018:540::-;8382:16;;;;8416:18;;8412:136;;8461:13;7841:723;-1:-1:-1;;;7841:723:64:o;5203:1551:44:-;5329:17;;;6283:66;6270:79;;6266:164;;;-1:-1:-1;6381:1:44;;-1:-1:-1;6385:30:44;;-1:-1:-1;6417:1:44;6365:54;;6266:164;6541:24;;;6524:14;6541:24;;;;;;;;;31087:25:126;;;31160:4;31148:17;;31128:18;;;31121:45;;;;31182:18;;;31175:34;;;31225:18;;;31218:34;;;6541:24:44;;31059:19:126;;6541:24:44;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;6541:24:44;;-1:-1:-1;;6541:24:44;;;-1:-1:-1;;;;;;;6579:20:44;;6575:113;;-1:-1:-1;6631:1:44;;-1:-1:-1;6635:29:44;;-1:-1:-1;6631:1:44;;-1:-1:-1;6615:62:44;;6575:113;6706:6;-1:-1:-1;6714:20:44;;-1:-1:-1;6714:20:44;;-1:-1:-1;5203:1551:44;;;;;;;;;:::o;788:226:81:-;859:9;;912:24;927:9;377:2;912:24;:::i;:::-;905:32;;:2;:32;:::i;:::-;975:23;;;;788:226;-1:-1:-1;;;788:226:81:o;10764:397:78:-;10809:6;10950:1;10946;:5;10938:31;;;;-1:-1:-1;;;10938:31:78;;31465:2:126;10938:31:78;;;31447:21:126;31504:2;31484:18;;;31477:30;-1:-1:-1;;;31523:18:126;;;31516:43;31576:18;;10938:31:78;31263:337:126;10938:31:78;2936:13;10987:21;-1:-1:-1;10987:46:78;;;;-1:-1:-1;2991:13:78;11012:21;;10987:46;10983:162;;;1907:4;11060:9;11067:1;11060:6;:9::i;:::-;:18;;;;;:::i;:::-;;;10764:397;-1:-1:-1;;10764:397:78:o;10983:162::-;11124:6;11128:1;11124:3;:6::i;10983:162::-;10764:397;;;:::o;4828:5831::-;4874:6;-1:-1:-1;;4924:1:78;:25;;:54;;;;;2692:6;4953:1;:25;;4924:54;4916:83;;;;-1:-1:-1;;;4916:83:78;;31807:2:126;4916:83:78;;;31789:21:126;31846:2;31826:18;;;31819:30;-1:-1:-1;;;31865:18:126;;;31858:46;31921:18;;4916:83:78;31605:340:126;4916:83:78;5022:1;5018;:5;5014:373;;;5364:7;5369:1;5368:2;;5364:3;:7::i;:::-;-1:-1:-1;;;5344:27:78;;;;;:::i;5014:373::-;6748:14;3132:21;6780:1;:7;6776:252;;-1:-1:-1;;;6807:7:78;;;;3188:56;6776:252;;;3296:20;6869:1;:7;6865:163;;-1:-1:-1;;;6896:7:78;;;;3351:28;6865:163;;;-1:-1:-1;6982:1:78;6865:163;7195:3;7190:8;;;;;2097:4;3460:22;7465:7;;7461:104;;-1:-1:-1;;7492:7:78;;;;2097:4;3517:34;7528:12;;7527:23;7517:33;;7461:104;3589:22;7582:1;:7;7578:104;;-1:-1:-1;;7609:7:78;;;;2097:4;3646:27;7645:12;;7644:23;7634:33;;7578:104;3711:21;7699:1;:7;7695:104;;-1:-1:-1;;7726:7:78;;;;2097:4;3767:24;7762:12;;7761:23;7751:33;;7695:104;3829:21;7816:1;:7;7812:104;;-1:-1:-1;;7843:7:78;;;;2097:4;3885:22;7879:12;;7878:23;7868:33;;7812:104;3945:21;7933:1;:7;7929:104;;-1:-1:-1;;7960:7:78;;;;2097:4;4001:21;7996:12;;7995:23;7985:33;;7929:104;4060:21;8050:1;:7;8046:104;;-1:-1:-1;;8077:7:78;;;;4060:21;4116;8113:12;;8112:23;8102:33;;8046:104;4175:20;8167:1;:7;8163:104;;-1:-1:-1;;8194:7:78;;;;2097:4;4231:21;8230:12;;8229:23;8219:33;;8163:104;4290:20;8284:1;:7;8280:104;;-1:-1:-1;;8311:7:78;;;;2097:4;4346:21;8347:12;;8346:23;8336:33;;8280:104;2097:4;8948:17;;;;;;9245:1;;9223:8;;;9222:19;9221:25;9260:17;;;;9221:25;-1:-1:-1;9323:1:78;2097:4;9301:8;;;9300:19;9299:25;9338:17;;;;9299:25;-1:-1:-1;9401:1:78;2097:4;9379:8;;;9378:19;9377:25;9416:17;;;;9377:25;-1:-1:-1;9479:1:78;2097:4;9457:8;;;9456:19;9455:25;9494:17;;;;9455:25;-1:-1:-1;9557:1:78;2097:4;9535:8;;;9534:19;9533:25;9572:17;;;;9533:25;-1:-1:-1;9635:1:78;2097:4;9613:8;;;9612:19;9611:25;9650:17;;;;9611:25;-1:-1:-1;9713:1:78;2097:4;9691:8;;;9690:19;9689:25;9728:17;;;;9689:25;-1:-1:-1;9791:1:78;2097:4;9769:8;;;9768:19;9767:25;9806:17;;;;9767:25;-1:-1:-1;9869:2:78;2097:4;9847:8;;;9846:19;9845:26;9885:17;;;;9845:26;-1:-1:-1;9948:2:78;2097:4;9926:8;;;9925:19;9924:26;9964:17;;;;9924:26;-1:-1:-1;10027:2:78;2097:4;10005:8;;;10004:19;10003:26;10043:17;;;;10003:26;-1:-1:-1;10639:3:78;2097:4;10595:19;;;10594:30;10593:42;;10592:50;;4828:5831;-1:-1:-1;;;;;;4828:5831:78:o;19574:1872::-;1907:4;19880:11;19622:6;;-1:-1:-1;;;20310:10:78;;;;-1:-1:-1;;20285:10:78;;20284:21;20310:10;20283:38;;;;:::i;:::-;;;-1:-1:-1;20335:16:78;-1:-1:-1;;;20355:5:78;;;20354:16;;-1:-1:-1;20472:1:78;;-1:-1:-1;;;20703:15:78;;;20702:26;;-1:-1:-1;20761:1:78;20702:26;20755:7;20742:20;-1:-1:-1;;;20784:15:78;;;20783:26;;-1:-1:-1;20842:1:78;20783:26;20836:7;20823:20;-1:-1:-1;;;20865:15:78;;;20864:26;;-1:-1:-1;20923:1:78;20864:26;20917:7;20904:20;-1:-1:-1;;;20946:15:78;;;20945:26;;-1:-1:-1;21004:1:78;20945:26;20998:7;20985:20;-1:-1:-1;;;21027:15:78;;;21026:26;;-1:-1:-1;21085:2:78;21026:26;21079:8;21066:21;-1:-1:-1;;;21109:15:78;;;21108:26;;-1:-1:-1;21167:2:78;21108:26;21161:8;21148:21;-1:-1:-1;;;21191:15:78;;;21190:26;;-1:-1:-1;21249:2:78;21190:26;21243:8;21230:21;21428:1;21416:13;;;-1:-1:-1;;;;;19574:1872:78:o;13911:5397::-;13956:6;1907:4;14002:1;:10;13998:402;;;14358:26;14382:1;-1:-1:-1;;;14382:1:78;14362:21;;;;:::i;:::-;;14358:3;:26::i;:::-;14357:27;;;13911:5397;-1:-1:-1;;13911:5397:78:o;13998:402::-;15781:10;15818:11;15813:16;;15809:126;;3188:56;15849:7;;;-1:-1:-1;3132:21:78;15911:9;15809:126;15958:11;15953:16;;15949:126;;3351:28;15989:7;;;-1:-1:-1;3296:20:78;16051:9;15949:126;16221:3;16238:8;;;;16214:10;3517:34;16381:7;;16377:94;;3517:34;2097:4;16413:10;;16412:17;;-1:-1:-1;3460:22:78;16447:9;16377:94;3646:27;16489:1;:7;16485:94;;3646:27;2097:4;16521:10;;16520:17;;-1:-1:-1;3589:22:78;16555:9;16485:94;3767:24;16597:1;:7;16593:94;;3767:24;2097:4;16629:10;;16628:17;;-1:-1:-1;3711:21:78;16663:9;16593:94;3885:22;16705:1;:7;16701:94;;3885:22;2097:4;16737:10;;16736:17;;-1:-1:-1;3829:21:78;16771:9;16701:94;4001:21;16813:1;:7;16809:94;;4001:21;2097:4;16845:10;;16844:17;;-1:-1:-1;3945:21:78;16879:9;16809:94;4116:21;16921:1;:7;16917:94;;4116:21;2097:4;16953:10;;;16952:17;;16987:9;16917:94;4231:21;17029:1;:7;17025:94;;4231:21;2097:4;17061:10;;17060:17;;-1:-1:-1;4175:20:78;17095:9;17025:94;4346:21;17137:1;:7;17133:94;;4346:21;2097:4;17169:10;;17168:17;;-1:-1:-1;4290:20:78;17203:9;17133:94;4463:21;17245:1;:8;17241:97;;4463:21;2097:4;17278:10;;17277:18;;-1:-1:-1;4406:20:78;17313:10;17241:97;4580:21;17356:1;:8;17352:97;;4580:21;2097:4;17389:10;;17388:18;;-1:-1:-1;4524:19:78;17424:10;17352:97;17979:8;2097:4;18017:1;:10;2097:4;;17992:1;:10;17991:21;17990:38;;;;;:::i;:::-;;;-1:-1:-1;18042:16:78;2097:4;18062:5;;;18061:16;;-1:-1:-1;18179:1:78;;2097:4;18410:15;;;18409:26;;-1:-1:-1;18468:1:78;18409:26;18462:7;18449:20;2097:4;18491:15;;;18490:26;;-1:-1:-1;18549:1:78;18490:26;18543:7;18530:20;2097:4;18572:15;;;18571:26;;-1:-1:-1;18630:1:78;18571:26;18624:7;18611:20;2097:4;18653:15;;;18652:26;;-1:-1:-1;18711:1:78;18652:26;18705:7;18692:20;2097:4;18734:15;;;18733:26;;-1:-1:-1;18792:2:78;18733:26;18786:8;18773:21;18978:1;18965:14;19288:3;19269:15;;;19268:23;;13911:5397;-1:-1:-1;;;;;;;13911:5397:78:o;14:367:126:-;77:8;87:6;141:3;134:4;126:6;122:17;118:27;108:55;;159:1;156;149:12;108:55;-1:-1:-1;182:20:126;;-1:-1:-1;;;;;214:30:126;;211:50;;;257:1;254;247:12;211:50;294:4;286:6;282:17;270:29;;354:3;347:4;337:6;334:1;330:14;322:6;318:27;314:38;311:47;308:67;;;371:1;368;361:12;308:67;14:367;;;;;:::o;386:437::-;472:6;480;533:2;521:9;512:7;508:23;504:32;501:52;;;549:1;546;539:12;501:52;589:9;576:23;-1:-1:-1;;;;;614:6:126;611:30;608:50;;;654:1;651;644:12;608:50;693:70;755:7;746:6;735:9;731:22;693:70;:::i;:::-;782:8;;667:96;;-1:-1:-1;386:437:126;-1:-1:-1;;;;386:437:126:o;828:420::-;881:3;919:5;913:12;946:6;941:3;934:19;978:4;973:3;969:14;962:21;;1017:4;1010:5;1006:16;1040:1;1050:173;1064:6;1061:1;1058:13;1050:173;;;1125:13;;1113:26;;1168:4;1159:14;;;;1196:17;;;;1086:1;1079:9;1050:173;;;-1:-1:-1;1239:3:126;;828:420;-1:-1:-1;;;;828:420:126:o;1253:465::-;1510:2;1499:9;1492:21;1473:4;1536:56;1588:2;1577:9;1573:18;1565:6;1536:56;:::i;:::-;1640:9;1632:6;1628:22;1623:2;1612:9;1608:18;1601:50;1668:44;1705:6;1697;1668:44;:::i;1905:641::-;2017:6;2025;2078:2;2066:9;2057:7;2053:23;2049:32;2046:52;;;2094:1;2091;2084:12;2046:52;2134:9;2121:23;-1:-1:-1;;;;;2159:6:126;2156:30;2153:50;;;2199:1;2196;2189:12;2153:50;2222:22;;2275:4;2267:13;;2263:27;-1:-1:-1;2253:55:126;;2304:1;2301;2294:12;2253:55;2344:2;2331:16;-1:-1:-1;;;;;2362:6:126;2359:30;2356:50;;;2402:1;2399;2392:12;2356:50;2460:7;2455:2;2445:6;2437;2433:19;2429:2;2425:28;2421:37;2418:50;2415:70;;;2481:1;2478;2471:12;2415:70;2512:2;2504:11;;;;;2534:6;;-1:-1:-1;1905:641:126;-1:-1:-1;;;1905:641:126:o;2551:226::-;2610:6;2663:2;2651:9;2642:7;2638:23;2634:32;2631:52;;;2679:1;2676;2669:12;2631:52;-1:-1:-1;2724:23:126;;2551:226;-1:-1:-1;2551:226:126:o;3099:131::-;-1:-1:-1;;;;;3174:31:126;;3164:42;;3154:70;;3220:1;3217;3210:12;3235:134;3303:20;;3332:31;3303:20;3332:31;:::i;3374:127::-;3435:10;3430:3;3426:20;3423:1;3416:31;3466:4;3463:1;3456:15;3490:4;3487:1;3480:15;3506:255;3578:2;3572:9;3620:6;3608:19;;-1:-1:-1;;;;;3642:34:126;;3678:22;;;3639:62;3636:88;;;3704:18;;:::i;:::-;3740:2;3733:22;3506:255;:::o;3766:253::-;3838:2;3832:9;3880:4;3868:17;;-1:-1:-1;;;;;3900:34:126;;3936:22;;;3897:62;3894:88;;;3962:18;;:::i;4024:251::-;4096:2;4090:9;;;4126:15;;-1:-1:-1;;;;;4156:34:126;;4192:22;;;4153:62;4150:88;;;4218:18;;:::i;4280:275::-;4351:2;4345:9;4416:2;4397:13;;-1:-1:-1;;4393:27:126;4381:40;;-1:-1:-1;;;;;4436:34:126;;4472:22;;;4433:62;4430:88;;;4498:18;;:::i;:::-;4534:2;4527:22;4280:275;;-1:-1:-1;4280:275:126:o;4560:198::-;4635:4;-1:-1:-1;;;;;4660:6:126;4657:30;4654:56;;;4690:18;;:::i;:::-;-1:-1:-1;4735:1:126;4731:14;4747:4;4727:25;;4560:198::o;4763:150::-;4838:20;;4887:1;4877:12;;4867:40;;4903:1;4900;4893:12;4918:1038;4970:5;5018:6;5006:9;5001:3;4997:19;4993:32;4990:52;;;5038:1;5035;5028:12;4990:52;5060:22;;:::i;:::-;5127:23;;5159:22;;5254:2;5239:18;;;5226:32;5274:14;;;5267:31;5371:2;5356:18;;;5343:32;5391:14;;;5384:31;5051;-1:-1:-1;5447:45:126;5488:2;5473:18;;5447:45;:::i;:::-;5442:2;5435:5;5431:14;5424:69;5526:39;5560:3;5549:9;5545:19;5526:39;:::i;:::-;5520:3;5513:5;5509:15;5502:64;5599:39;5633:3;5622:9;5618:19;5599:39;:::i;:::-;5593:3;5586:5;5582:15;5575:64;5672:39;5706:3;5695:9;5691:19;5672:39;:::i;:::-;5666:3;5655:15;;5648:64;5785:3;5770:19;;;5757:33;5806:15;;;5799:32;5904:3;5889:19;;;5876:33;5925:15;;;5918:32;;;;5659:5;4918:1038;-1:-1:-1;4918:1038:126:o;5961:558::-;6003:5;6056:3;6049:4;6041:6;6037:17;6033:27;6023:55;;6074:1;6071;6064:12;6023:55;6114:6;6101:20;-1:-1:-1;;;;;6136:6:126;6133:30;6130:56;;;6166:18;;:::i;:::-;6210:59;6257:2;6234:17;;-1:-1:-1;;6230:31:126;6263:4;6226:42;6210:59;:::i;:::-;6294:6;6285:7;6278:23;6348:3;6341:4;6332:6;6324;6320:19;6316:30;6313:39;6310:59;;;6365:1;6362;6355:12;6310:59;6430:6;6423:4;6415:6;6411:17;6404:4;6395:7;6391:18;6378:59;6486:1;6457:20;;;6479:4;6453:31;6446:42;;;;6461:7;5961:558;-1:-1:-1;;;5961:558:126:o;6524:1337::-;6618:5;6647:79;6663:62;6718:6;6663:62;:::i;:::-;6647:79;:::i;:::-;6760:21;;;6638:88;-1:-1:-1;6808:4:126;6797:16;;6852:1;6848:14;;;6836:27;;6875:15;;;6872:35;;;6903:1;6900;6893:12;6872:35;6927:6;6942:913;6958:6;6953:3;6950:15;6942:913;;;7046:3;7033:17;-1:-1:-1;;;;;7069:11:126;7066:35;7063:55;;;7114:1;7111;7104:12;7063:55;7141:24;;7199:6;7185:12;;;7181:25;7178:45;;;7219:1;7216;7209:12;7178:45;7249:22;;:::i;:::-;7298:32;7326:3;7322:2;7298:32;:::i;:::-;7291:5;7284:47;7381:3;7377:2;7373:12;7360:26;-1:-1:-1;;;;;7405:8:126;7402:32;7399:52;;;7447:1;7444;7437:12;7399:52;7489:40;7525:3;7514:8;7510:2;7506:17;7489:40;:::i;:::-;7482:4;7471:16;;;7464:66;;;;7604:3;7596:12;;7583:26;7640:4;7629:16;;7622:33;7729:3;7721:12;;;7708:26;7765:4;7754:16;;7747:33;-1:-1:-1;7793:18:126;;7831:14;;;;6975;6942:913;;;6946:3;;;6524:1337;;;;;:::o;7866:274::-;7935:5;7988:3;7981:4;7973:6;7969:17;7965:27;7955:55;;8006:1;8003;7996:12;7955:55;8028:106;8130:3;8121:6;8108:20;8101:4;8093:6;8089:17;8028:106;:::i;8145:746::-;8290:6;8298;8306;8359:2;8347:9;8338:7;8334:23;8330:32;8327:52;;;8375:1;8372;8365:12;8327:52;8414:9;8401:23;8433:31;8458:5;8433:31;:::i;:::-;8483:5;-1:-1:-1;8539:2:126;8524:18;;8511:32;-1:-1:-1;;;;;8555:30:126;;8552:50;;;8598:1;8595;8588:12;8552:50;8621:76;8689:7;8680:6;8669:9;8665:22;8621:76;:::i;:::-;8611:86;;;8750:2;8739:9;8735:18;8722:32;-1:-1:-1;;;;;8769:8:126;8766:32;8763:52;;;8811:1;8808;8801:12;8763:52;8834:51;8877:7;8866:8;8855:9;8851:24;8834:51;:::i;:::-;8824:61;;;8145:746;;;;;:::o;9088:225::-;9171:6;9224:3;9212:9;9203:7;9199:23;9195:33;9192:53;;;9241:1;9238;9231:12;9192:53;9264:43;9299:7;9288:9;9264:43;:::i;9500:230::-;9585:6;9645:3;9633:9;9624:7;9620:23;9616:33;9661:2;9658:22;;;9676:1;9673;9666:12;9658:22;-1:-1:-1;9715:9:126;;9500:230;-1:-1:-1;;9500:230:126:o;9735:247::-;9794:6;9847:2;9835:9;9826:7;9822:23;9818:32;9815:52;;;9863:1;9860;9853:12;9815:52;9902:9;9889:23;9921:31;9946:5;9921:31;:::i;9987:114::-;10071:4;10064:5;10060:16;10053:5;10050:27;10040:55;;10091:1;10088;10081:12;10106:243;10163:6;10216:2;10204:9;10195:7;10191:23;10187:32;10184:52;;;10232:1;10229;10222:12;10184:52;10271:9;10258:23;10290:29;10313:5;10290:29;:::i;10354:289::-;10396:3;10434:5;10428:12;10461:6;10456:3;10449:19;10517:6;10510:4;10503:5;10499:16;10492:4;10487:3;10483:14;10477:47;10569:1;10562:4;10553:6;10548:3;10544:16;10540:27;10533:38;10632:4;10625:2;10621:7;10616:2;10608:6;10604:15;10600:29;10595:3;10591:39;10587:50;10580:57;;;10354:289;;;;:::o;10648:920::-;11054:3;11049;11045:13;11037:6;11033:26;11022:9;11015:45;11096:3;11091:2;11080:9;11076:18;11069:31;10996:4;11123:46;11164:3;11153:9;11149:19;11141:6;11123:46;:::i;:::-;11217:9;11209:6;11205:22;11200:2;11189:9;11185:18;11178:50;11251:33;11277:6;11269;11251:33;:::i;:::-;11315:2;11300:18;;11293:34;;;-1:-1:-1;;;;;11364:32:126;;11358:3;11343:19;;11336:61;11384:3;11413:19;;11406:35;;;11478:22;;;11472:3;11457:19;;11450:51;11237:47;-1:-1:-1;11518:44:126;11237:47;11547:6;11518:44;:::i;12051:1012::-;12385:3;12398:22;;;12469:13;;12370:19;;;12491:22;;;12337:4;;12583;12571:17;;;12544:3;12529:19;;;12337:4;12616:262;12630:6;12627:1;12624:13;12616:262;;;12689:13;;12727:9;;12715:22;;12787:4;12779:13;;;12773:20;12757:14;;;12750:44;12851:17;;;;12823:4;12814:14;;;;12652:1;12645:9;12616:262;;;-1:-1:-1;;;;;;;12936:32:126;;;;12929:4;12914:20;;12907:62;-1:-1:-1;;13000:4:126;12985:20;;12978:36;;;;13045:2;13030:18;;;13023:34;12895:3;12051:1012;-1:-1:-1;12051:1012:126:o;13068:2005::-;13286:6;13294;13302;13310;13318;13326;13379:3;13367:9;13358:7;13354:23;13350:33;13347:53;;;13396:1;13393;13386:12;13347:53;13435:9;13422:23;13454:31;13479:5;13454:31;:::i;:::-;13504:5;-1:-1:-1;13560:2:126;13545:18;;13532:32;-1:-1:-1;;;;;13576:30:126;;13573:50;;;13619:1;13616;13609:12;13573:50;13642:76;13710:7;13701:6;13690:9;13686:22;13642:76;:::i;:::-;13632:86;;;13771:2;13760:9;13756:18;13743:32;-1:-1:-1;;;;;13790:8:126;13787:32;13784:52;;;13832:1;13829;13822:12;13784:52;13855:24;;13910:4;13902:13;;13898:27;-1:-1:-1;13888:55:126;;13939:1;13936;13929:12;13888:55;13979:2;13966:16;14002:79;14018:62;14073:6;14018:62;:::i;14002:79::-;14103:3;14127:6;14122:3;14115:19;14159:2;14154:3;14150:12;14143:19;;14214:2;14204:6;14201:1;14197:14;14193:2;14189:23;14185:32;14171:46;;14240:7;14232:6;14229:19;14226:39;;;14261:1;14258;14251:12;14226:39;14293:2;14289;14285:11;14274:22;;14305:473;14321:6;14316:3;14313:15;14305:473;;;14401:2;14395:3;14386:7;14382:17;14378:26;14375:46;;;14417:1;14414;14407:12;14375:46;14449:22;;:::i;:::-;14524:17;;14554:24;;14653:2;14644:12;;;14631:26;14677:16;;;14670:33;14716:20;;;14347:2;14338:12;;;;14756;;;;;14305:473;;;14797:5;-1:-1:-1;14821:38:126;;-1:-1:-1;;;14855:2:126;14840:18;;14821:38;:::i;:::-;13068:2005;;;;-1:-1:-1;13068:2005:126;;14932:3;14917:19;;14904:33;;15036:3;15021:19;;;15008:33;;-1:-1:-1;13068:2005:126;-1:-1:-1;;13068:2005:126:o;15285:529::-;15362:6;15370;15378;15431:2;15419:9;15410:7;15406:23;15402:32;15399:52;;;15447:1;15444;15437:12;15399:52;15486:9;15473:23;15505:31;15530:5;15505:31;:::i;:::-;15555:5;-1:-1:-1;15612:2:126;15597:18;;15584:32;15625:33;15584:32;15625:33;:::i;:::-;15677:7;-1:-1:-1;15736:2:126;15721:18;;15708:32;15749:33;15708:32;15749:33;:::i;:::-;15801:7;15791:17;;;15285:529;;;;;:::o;15819:367::-;15887:6;15895;15948:2;15936:9;15927:7;15923:23;15919:32;15916:52;;;15964:1;15961;15954:12;15916:52;16003:9;15990:23;16022:31;16047:5;16022:31;:::i;:::-;16072:5;16150:2;16135:18;;;;16122:32;;-1:-1:-1;;;15819:367:126:o;16191:127::-;16252:10;16247:3;16243:20;16240:1;16233:31;16283:4;16280:1;16273:15;16307:4;16304:1;16297:15;16576:251;16646:6;16699:2;16687:9;16678:7;16674:23;16670:32;16667:52;;;16715:1;16712;16705:12;16667:52;16747:9;16741:16;16766:31;16791:5;16766:31;:::i;17096:127::-;17157:10;17152:3;17148:20;17145:1;17138:31;17188:4;17185:1;17178:15;17212:4;17209:1;17202:15;17228:1158;17396:4;17438:3;17427:9;17423:19;17415:27;;17469:6;17458:9;17451:25;17518:6;17512:13;17507:2;17496:9;17492:18;17485:41;17580:2;17572:6;17568:15;17562:22;17557:2;17546:9;17542:18;17535:50;17639:2;17631:6;17627:15;17621:22;17616:2;17605:9;17601:18;17594:50;17691:2;17683:6;17679:15;17673:22;17731:1;17717:12;17714:19;17704:150;;17776:10;17771:3;17767:20;17764:1;17757:31;17811:4;17808:1;17801:15;17839:4;17836:1;17829:15;17704:150;17891:12;17885:3;17874:9;17870:19;17863:41;;17953:3;17945:6;17941:16;17935:23;17967:55;18017:3;18006:9;18002:19;17986:14;-1:-1:-1;;;;;2848:31:126;2836:44;;2782:104;17967:55;-1:-1:-1;18071:3:126;18059:16;;18053:23;-1:-1:-1;;;;;2848:31:126;;18135:3;18120:19;;2836:44;-1:-1:-1;18189:3:126;18177:16;;18171:23;-1:-1:-1;;;;;2848:31:126;;18253:3;18238:19;;2836:44;18203:55;18313:3;18305:6;18301:16;18295:23;18289:3;18278:9;18274:19;18267:52;18374:3;18366:6;18362:16;18356:23;18350:3;18339:9;18335:19;18328:52;17228:1158;;;;;:::o;18391:127::-;18452:10;18447:3;18443:20;18440:1;18433:31;18483:4;18480:1;18473:15;18507:4;18504:1;18497:15;18523:125;18588:9;;;18609:10;;;18606:36;;;18622:18;;:::i;18932:128::-;18999:9;;;19020:11;;;19017:37;;;19034:18;;:::i;19415:320::-;19601:9;19638:91;19714:14;19706:6;19699:5;19638:91;:::i;19954:331::-;20059:9;20070;20112:8;20100:10;20097:24;20094:44;;;20134:1;20131;20124:12;20094:44;20163:6;20153:8;20150:20;20147:40;;;20183:1;20180;20173:12;20147:40;-1:-1:-1;;20209:23:126;;;20254:25;;;;;-1:-1:-1;19954:331:126:o;20290:338::-;20410:19;;-1:-1:-1;;;;;;20447:29:126;;;20496:1;20488:10;;20485:137;;;-1:-1:-1;;;;;;20557:1:126;20553:11;;;20550:1;20546:19;20542:46;;;20534:55;;20530:82;;-1:-1:-1;20485:137:126;;20290:338;;;;:::o;20633:485::-;-1:-1:-1;;;;;20818:32:126;;20800:51;;20887:2;20882;20867:18;;20860:30;;;20906:18;;20899:34;;;20926:6;20975;20970:2;20955:18;;20942:48;21039:1;21010:22;;;21034:2;21006:31;;;20999:42;;;;21102:2;21081:15;;;-1:-1:-1;;21077:29:126;21062:45;21058:54;;20633:485;-1:-1:-1;;20633:485:126:o;21123:135::-;21162:3;21183:17;;;21180:43;;21203:18;;:::i;:::-;-1:-1:-1;21250:1:126;21239:13;;21123:135::o;21263:184::-;21333:6;21386:2;21374:9;21365:7;21361:23;21357:32;21354:52;;;21402:1;21399;21392:12;21354:52;-1:-1:-1;21425:16:126;;21263:184;-1:-1:-1;21263:184:126:o;22100:380::-;22179:1;22175:12;;;;22222;;;22243:61;;22297:4;22289:6;22285:17;22275:27;;22243:61;22350:2;22342:6;22339:14;22319:18;22316:38;22313:161;;22396:10;22391:3;22387:20;22384:1;22377:31;22431:4;22428:1;22421:15;22459:4;22456:1;22449:15;22886:375;22974:1;22992:5;23006:249;23027:1;23017:8;23014:15;23006:249;;;23077:4;23072:3;23068:14;23062:4;23059:24;23056:50;;;23086:18;;:::i;:::-;23136:1;23126:8;23122:16;23119:49;;;23150:16;;;;23119:49;23233:1;23229:16;;;;;23189:15;;23006:249;;;22886:375;;;;;;:::o;23266:902::-;23315:5;23345:8;23335:80;;-1:-1:-1;23386:1:126;23400:5;;23335:80;23434:4;23424:76;;-1:-1:-1;23471:1:126;23485:5;;23424:76;23516:4;23534:1;23529:59;;;;23602:1;23597:174;;;;23509:262;;23529:59;23559:1;23550:10;;23573:5;;;23597:174;23634:3;23624:8;23621:17;23618:43;;;23641:18;;:::i;:::-;-1:-1:-1;;23697:1:126;23683:16;;23756:5;;23509:262;;23855:2;23845:8;23842:16;23836:3;23830:4;23827:13;23823:36;23817:2;23807:8;23804:16;23799:2;23793:4;23790:12;23786:35;23783:77;23780:203;;;-1:-1:-1;23892:19:126;;;23968:5;;23780:203;24015:42;-1:-1:-1;;24040:8:126;24034:4;24015:42;:::i;:::-;24093:6;24089:1;24085:6;24081:19;24072:7;24069:32;24066:58;;;24104:18;;:::i;:::-;24142:20;;23266:902;-1:-1:-1;;;23266:902:126:o;24173:131::-;24233:5;24262:36;24289:8;24283:4;24262:36;:::i;24309:168::-;24382:9;;;24413;;24430:15;;;24424:22;;24410:37;24400:71;;24451:18;;:::i;24482:127::-;24543:10;24538:3;24534:20;24531:1;24524:31;24574:4;24571:1;24564:15;24598:4;24595:1;24588:15;24614:120;24654:1;24680;24670:35;;24685:18;;:::i;:::-;-1:-1:-1;24719:9:126;;24614:120::o;26078:518::-;26180:2;26175:3;26172:11;26169:421;;;26216:5;26213:1;26206:16;26260:4;26257:1;26247:18;26330:2;26318:10;26314:19;26311:1;26307:27;26301:4;26297:38;26366:4;26354:10;26351:20;26348:47;;;-1:-1:-1;26389:4:126;26348:47;26444:2;26439:3;26435:12;26432:1;26428:20;26422:4;26418:31;26408:41;;26499:81;26517:2;26510:5;26507:13;26499:81;;;26576:1;26562:16;;26543:1;26532:13;26499:81;;;26503:3;;26078:518;;;:::o;26772:1299::-;26898:3;26892:10;-1:-1:-1;;;;;26917:6:126;26914:30;26911:56;;;26947:18;;:::i;:::-;26976:97;27066:6;27026:38;27058:4;27052:11;27026:38;:::i;:::-;27020:4;26976:97;:::i;:::-;27122:4;27153:2;27142:14;;27170:1;27165:649;;;;27858:1;27875:6;27872:89;;;-1:-1:-1;27927:19:126;;;27921:26;27872:89;-1:-1:-1;;26729:1:126;26725:11;;;26721:24;26717:29;26707:40;26753:1;26749:11;;;26704:57;27974:81;;27135:930;;27165:649;26025:1;26018:14;;;26062:4;26049:18;;-1:-1:-1;;27201:20:126;;;27319:222;27333:7;27330:1;27327:14;27319:222;;;27415:19;;;27409:26;27394:42;;27522:4;27507:20;;;;27475:1;27463:14;;;;27349:12;27319:222;;;27323:3;27569:6;27560:7;27557:19;27554:201;;;27630:19;;;27624:26;-1:-1:-1;;27713:1:126;27709:14;;;27725:3;27705:24;27701:37;27697:42;27682:58;27667:74;;27554:201;-1:-1:-1;;;;27801:1:126;27785:14;;;27781:22;27768:36;;-1:-1:-1;26772:1299:126:o;28857:289::-;29032:6;29021:9;29014:25;29075:2;29070;29059:9;29055:18;29048:30;28995:4;29095:45;29136:2;29125:9;29121:18;29113:6;29095:45;:::i;29151:301::-;29280:3;29318:6;29312:13;29364:6;29357:4;29349:6;29345:17;29340:3;29334:37;29426:1;29390:16;;29415:13;;;-1:-1:-1;29390:16:126;29151:301;-1:-1:-1;29151:301:126:o;29646:247::-;29714:6;29767:2;29755:9;29746:7;29742:23;29738:32;29735:52;;;29783:1;29780;29773:12;29735:52;29815:9;29809:16;29834:29;29857:5;29834:29;:::i;29898:151::-;29988:4;29981:12;;;29967;;;29963:31;;30006:14;;30003:40;;;30023:18;;:::i;30054:140::-;30112:5;30141:47;30182:4;30172:8;30168:19;30162:4;30141:47;:::i;30199:193::-;30238:1;30264;30254:35;;30269:18;;:::i;:::-;-1:-1:-1;;;30305:18:126;;-1:-1:-1;;30325:13:126;;30301:38;30298:64;;;30342:18;;:::i;:::-;-1:-1:-1;30376:10:126;;30199:193::o;30397:216::-;30461:9;;;30489:11;;;30436:3;30519:9;;30547:10;;30543:19;;30572:10;;30564:19;;30540:44;30537:70;;;30587:18;;:::i;:::-;30537:70;;30397:216;;;;:::o;30618:237::-;30690:9;;;30657:7;30715:9;;-1:-1:-1;;;30726:18:126;;30711:34;30708:60;;;30748:18;;:::i;:::-;30821:1;30812:7;30807:16;30804:1;30801:23;30797:1;30790:9;30787:38;30777:72;;30829:18;;:::i",
+    "linkReferences": {}
+  },
+  "methodIdentifiers": {
+    "MAX_LIMIT_ORDER_FEE()": "3b733c66",
+    "advanceNonce(uint8)": "72c244a8",
+    "authority()": "bf7e214f",
+    "cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])": "6ee83986",
+    "cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": "71c707eb",
+    "eip712Domain()": "84b0196e",
+    "feeRecipient()": "46904840",
+    "fillOrders(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],bytes)": "4cb4069e",
+    "getLimitOrderFee()": "34b08c05",
+    "hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": "64278cf6",
+    "increaseNonce()": "c53a0292",
+    "initialize(address,address,address)": "c0c53b8b",
+    "isConsumingScheduledOp()": "8fb36037",
+    "nonce(address)": "70ae92d2",
+    "nonceEquals(address,uint256)": "cf6fc6e3",
+    "orderStatuses(bytes32[])": "0c0b8c9c",
+    "orderStatusesRaw(bytes32[])": "35ee3ffc",
+    "pause()": "8456cb59",
+    "paused()": "5c975abb",
+    "preSignBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])": "3e076174",
+    "preSignSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": "6bec6723",
+    "registry()": "7b103999",
+    "router()": "f887ea40",
+    "setAuthority(address)": "7a9e5e4b",
+    "setLimitOrderFee(uint256)": "458edd74",
+    "setRouter(address)": "c0d78655",
+    "transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256,uint256)": "8ed9b04b",
+    "unpause()": "3f4ba83a",
+    "validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[])": "8b96e39e"
+  },
+  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.28+commit.7893614a\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"authority\",\"type\":\"address\"}],\"name\":\"AccessManagedInvalidAuthority\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"delay\",\"type\":\"uint32\"}],\"name\":\"AccessManagedRequiredDelay\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"}],\"name\":\"AccessManagedUnauthorized\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderId\",\"type\":\"bytes32\"}],\"name\":\"AlreadyFilled\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EnforcedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ExpectedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"FeeGreaterThanMaxValue\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"IncompatibleOrderBatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InsufficientFunds\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidBatchParams\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidOrderForPreSign\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidOrderType\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MaxTakingExceeded\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NegativeImpliedRate\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NoValidOrder\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotMaker\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotRouter\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"name\":\"OrderAlreadyRegistered\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderId\",\"type\":\"bytes32\"}],\"name\":\"OrderNotExisting\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ReentrancyGuardReentrantCall\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"bits\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"SafeCastOverflowedUintDowncast\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"token\",\"type\":\"address\"}],\"name\":\"SafeERC20FailedOperation\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"authority\",\"type\":\"address\"}],\"name\":\"AuthorityUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newFeeRecipient\",\"type\":\"address\"}],\"name\":\"FeeRecipientUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"previousLimitOrderFee\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newLimitOrderFee\",\"type\":\"uint256\"}],\"name\":\"LimitOrderFeeChange\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"oldNonce\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newNonce\",\"type\":\"uint256\"}],\"name\":\"NonceIncreased\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"name\":\"OrderCanceled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"actualMaking\",\"type\":\"uint256\"}],\"name\":\"OrderFilled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"}],\"name\":\"OrderPreSigned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Paused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newRouter\",\"type\":\"address\"}],\"name\":\"RouterUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Unpaused\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"MAX_LIMIT_ORDER_FEE\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"amount\",\"type\":\"uint8\"}],\"name\":\"advanceNonce\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"authority\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"pt\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.Order[]\",\"name\":\"orders\",\"type\":\"tuple[]\"}],\"name\":\"cancelBatch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"pt\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"}],\"name\":\"cancelSingle\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"feeRecipient\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"pt\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxTaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.FillOrderParams[]\",\"name\":\"params\",\"type\":\"tuple[]\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"fillOrders\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getLimitOrderFee\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"pt\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"}],\"name\":\"hashOrder\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"increaseNonce\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_registry\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_router\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_initialAuthority\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"isConsumingScheduledOp\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"nonce\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"makerAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makerNonce\",\"type\":\"uint256\"}],\"name\":\"nonceEquals\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"orderHashes\",\"type\":\"bytes32[]\"}],\"name\":\"orderStatuses\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"remainings\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"filledAmounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"orderHashes\",\"type\":\"bytes32[]\"}],\"name\":\"orderStatusesRaw\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"remainingsRaw\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"filledAmounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"paused\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"pt\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.Order[]\",\"name\":\"orders\",\"type\":\"tuple[]\"}],\"name\":\"preSignBatch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"pt\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"}],\"name\":\"preSignSingle\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"registry\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"router\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newAuthority\",\"type\":\"address\"}],\"name\":\"setAuthority\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_limitOrderFee\",\"type\":\"uint256\"}],\"name\":\"setLimitOrderFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newRouter\",\"type\":\"address\"}],\"name\":\"setRouter\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"pt\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxTaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.FillOrderParams[]\",\"name\":\"params\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"actualTaking\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"actualMaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.OrderResult[]\",\"name\":\"validatedResults\",\"type\":\"tuple[]\"},{\"internalType\":\"address\",\"name\":\"takerToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"totalTaking\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalFees\",\"type\":\"uint256\"}],\"name\":\"transferPostValidation\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"unpause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"pt\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxTaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.FillOrderParams[]\",\"name\":\"params\",\"type\":\"tuple[]\"}],\"name\":\"validateOrdersAndUpdateStatus\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"actualTaking\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"actualMaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.OrderResult[]\",\"name\":\"validatedResults\",\"type\":\"tuple[]\"},{\"internalType\":\"address\",\"name\":\"takerToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"totalTaking\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalFees\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"EnforcedPause()\":[{\"details\":\"The operation failed because the contract is paused.\"}],\"ExpectedPause()\":[{\"details\":\"The operation failed because the contract is not paused.\"}],\"InvalidInitialization()\":[{\"details\":\"The contract is already initialized.\"}],\"NotInitializing()\":[{\"details\":\"The contract is not initializing.\"}],\"ReentrancyGuardReentrantCall()\":[{\"details\":\"Unauthorized reentrant call.\"}],\"SafeCastOverflowedUintDowncast(uint8,uint256)\":[{\"details\":\"Value doesn't fit in an uint of `bits` size.\"}],\"SafeERC20FailedOperation(address)\":[{\"details\":\"An operation with an ERC-20 token failed.\"}]},\"events\":{\"AuthorityUpdated(address)\":{\"details\":\"Authority that manages this contract was updated.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"Initialized(uint64)\":{\"details\":\"Triggered when the contract has been initialized or reinitialized.\"},\"Paused(address)\":{\"details\":\"Emitted when the pause is triggered by `account`.\"},\"Unpaused(address)\":{\"details\":\"Emitted when the pause is lifted by `account`.\"}},\"kind\":\"dev\",\"methods\":{\"advanceNonce(uint8)\":{\"params\":{\"amount\":\"The amount by which to advance the nonce\"}},\"authority()\":{\"details\":\"Returns the current authority.\"},\"cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])\":{\"details\":\"Loops through orders and cancels each one.\",\"params\":{\"orders\":\"Array of orders to cancel.\"}},\"cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))\":{\"details\":\"Sets order status as filled and emits an event.\",\"params\":{\"order\":\"The order to cancel.\"}},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"fillOrders(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],bytes)\":{\"details\":\"Must be called by the authorized router, which has already transferred the      taker input token to this contract before the call.All orders in the batch must share the same PT and a compatible OrderType.\",\"params\":{\"data\":\"ABI-encoded address of the taker's input token.\",\"params\":\"Array of FillOrderParams containing order details and fill amounts.\",\"receiver\":\"Address that receives the taker's output tokens (and any dust).\"}},\"getLimitOrderFee()\":{\"returns\":{\"_0\":\"The current protocol limit-order fee in 18-decimal WAD.\"}},\"hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))\":{\"params\":{\"order\":\"The order to hash\"},\"returns\":{\"_0\":\"The order's hash as bytes32\"}},\"increaseNonce()\":{\"details\":\"Calls `advanceNonce(1)` internally\"},\"isConsumingScheduledOp()\":{\"details\":\"Returns true only in the context of a delayed restricted call, at the moment that the scheduled operation is being consumed. Prevents denial of service for delayed restricted calls in the case that the contract performs attacker controlled calls.\"},\"nonceEquals(address,uint256)\":{\"params\":{\"makerAddress\":\"The address of the maker\",\"makerNonce\":\"The nonce to check against\"},\"returns\":{\"_0\":\"result True if `makerAddress` has the specified nonce, otherwise false\"}},\"orderStatuses(bytes32[])\":{\"details\":\"Adjusts raw remaining values by subtracting one to confirm order existence\",\"params\":{\"orderHashes\":\"Array of order hashes to query\"},\"returns\":{\"filledAmounts\":\"Filled amounts for each order\",\"remainings\":\"Processed remaining amounts for each order\"}},\"orderStatusesRaw(bytes32[])\":{\"params\":{\"orderHashes\":\"Array of order hashes to query\"},\"returns\":{\"filledAmounts\":\"Filled amounts for each order\",\"remainingsRaw\":\"Raw remaining amounts for each order\"}},\"paused()\":{\"details\":\"Returns true if the contract is paused, and false otherwise.\"},\"preSignBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])\":{\"details\":\"Loops through orders and pre-signs each one. Reverts if any order fails its checks.\",\"params\":{\"orders\":\"Array of orders to pre-sign.\"}},\"preSignSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))\":{\"details\":\"Allows fillers to skip EIP-712 signature verification for this order. The caller must be      the order's maker, the order must pass basic requirements (expiry/maturity/nonce), and the      order must not already exist (no prior fill, presign, or cancellation).\",\"params\":{\"order\":\"The order to pre-sign.\"}},\"setAuthority(address)\":{\"details\":\"Transfers control to a new authority. The caller must be the current authority.\"},\"setLimitOrderFee(uint256)\":{\"details\":\"Restricted to the access manager. Reverts with `FeeGreaterThanMaxValue` if the new      fee exceeds `MAX_LIMIT_ORDER_FEE`.\",\"params\":{\"_limitOrderFee\":\"The new fee value in 18-decimal WAD (e.g. 1e16 = 1%).\"}},\"setRouter(address)\":{\"details\":\"This function allows an authorized entity to change the router contract.\",\"params\":{\"_newRouter\":\"The new router contract address.\"}},\"transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256,uint256)\":{\"details\":\"Must be called by the authorized router after `validateOrdersAndUpdateStatus` and      after the router has transferred the taker input token to this contract.\",\"params\":{\"params\":\"Order parameters (used to route maker payments and derive PT address).\",\"receiver\":\"Address that receives remaining tokens after maker settlement and fees.\",\"takerToken\":\"Token owed to makers and fee recipient.\",\"totalFees\":\"Total fees to send to feeRecipient.\",\"totalTaking\":\"Total takerToken required (must be held by this contract).\",\"validatedResults\":\"Results returned by `validateOrdersAndUpdateStatus`.\"}},\"validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[])\":{\"details\":\"Must be called by the authorized router contract only.All orders must share the same PT and a compatible OrderType.\",\"params\":{\"params\":\"Array of FillOrderParams containing order details and fill amounts\"},\"returns\":{\"takerToken\":\"Address of the token being taken from the taker\",\"totalFees\":\"Aggregate fees collected from the transaction\",\"totalTaking\":\"Aggregate takerToken required (fees included)\",\"validatedResults\":\"Array of OrderResult structs with actual amounts per order\"}}},\"stateVariables\":{\"router\":{\"return\":\"The address of the current router contract.\",\"returns\":{\"_0\":\"The address of the current router contract.\"}}},\"title\":\"LimitOrderEngine\",\"version\":1},\"userdoc\":{\"errors\":{\"NotMaker()\":[{\"notice\":\"Errors\"}]},\"events\":{\"OrderCanceled(address,bytes32)\":{\"notice\":\"Events\"}},\"kind\":\"user\",\"methods\":{\"advanceNonce(uint8)\":{\"notice\":\"Advances the nonce of the sender by a specified amount\"},\"cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])\":{\"notice\":\"Cancels multiple orders in a batch.\"},\"cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))\":{\"notice\":\"Cancels a single order.\"},\"feeRecipient()\":{\"notice\":\"=== Getters ===\"},\"fillOrders(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],bytes)\":{\"notice\":\"Fills orders end-to-end: validates, pulls maker funds, handles optional         protocol deposit/withdraw, settles makers, collects fees, and returns         remaining balances to the receiver.\"},\"getLimitOrderFee()\":{\"notice\":\"Retrieves the current limit-order fee.\"},\"hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))\":{\"notice\":\"Computes a unique hash for an order\"},\"increaseNonce()\":{\"notice\":\"Advances the nonce of the sender by one\"},\"nonce(address)\":{\"notice\":\"Returns the current nonce for a given address\"},\"nonceEquals(address,uint256)\":{\"notice\":\"Checks if a given nonce matches the expected nonce for a maker\"},\"orderStatuses(bytes32[])\":{\"notice\":\"Gets processed order statuses\"},\"orderStatusesRaw(bytes32[])\":{\"notice\":\"Gets raw remaining and filled amounts for orders\"},\"preSignBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])\":{\"notice\":\"Pre-signs multiple orders on-chain.\"},\"preSignSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))\":{\"notice\":\"Pre-signs a single order on-chain by setting the remaining amount to makingAmount + 1.\"},\"router()\":{\"notice\":\"Retrieves the current router address.\"},\"setLimitOrderFee(uint256)\":{\"notice\":\"Updates the protocol limit-order fee.\"},\"setRouter(address)\":{\"notice\":\"Updates the router address.\"},\"transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256,uint256)\":{\"notice\":\"Settles validated orders: checks engine balance, pays makers, collects fees,         and sweeps remaining IBT/PT/YT to the receiver.\"},\"validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[])\":{\"notice\":\"Validates orders, updates their status, and calculates aggregate totals.\"}},\"notice\":\"Contract for managing limit orders, including validation, status tracking, and cancellation\",\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/LimitOrderEngine.sol\":\"LimitOrderEngine\"},\"evmVersion\":\"prague\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":@openzeppelin-contracts-5.4.0-rc.1/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/\",\":@openzeppelin-contracts-upgradeable-5.4.0-rc.1/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/\",\":config/=dependencies/spectra-contracts-configs-main/script/\",\":core-v2-staging/=dependencies/core-v2-staging/src/\",\":core-v2/=dependencies/core-v2-staging/\",\":diamond-router-V1/=dependencies/core-v2-staging/dependencies/diamond-router-V1/src/\",\":ds-test/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/forge-std/lib/ds-test/src/\",\":erc4626-tests/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/openzeppelin-contracts-upgradeable/lib/erc4626-tests/\",\":forge-std-1.9.7/=dependencies/forge-std-1.9.7/src/\",\":forge-std/=dependencies/forge-std-1.9.7/src/\",\":halmos-cheatcodes/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/openzeppelin-contracts-upgradeable/lib/halmos-cheatcodes/src/\",\":openzeppelin-contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/\",\":openzeppelin-contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/\",\":openzeppelin-erc20-basic/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/token/ERC20/\",\":openzeppelin-math/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/utils/math/\",\":roles/=dependencies/spectra-contracts-configs-main/access/\",\":solidity-stringutils/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/solidity-stringutils/\",\":spectra-contracts-configs-main/=dependencies/spectra-contracts-configs-main/src/\",\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/:@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/\",\"dependencies/core-v2-staging:script/=dependencies/core-v2-staging/script/\",\"dependencies/core-v2-staging:src/=dependencies/core-v2-staging/src/\"]},\"sources\":{\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/AuthorityUtils.sol\":{\"keccak256\":\"0x05fd06ae5bca9dc7470fb2dfae764315c81a84f591e86be6fec0c115474edc6c\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://998ffed150fad3264d73c847f2ca35ee750d747ece382bb48885e8c8dce62941\",\"dweb:/ipfs/QmSjacwVExF2T9ZFysQQ3vVLJbDQ16G7zd81SDxPCfNFxe\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAccessManaged.sol\":{\"keccak256\":\"0x4ad12e231e8b1567e4086b134f5ff59a08cb8b1ea6d8fa9ecceec30b4b28ad89\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://81657c0f105f4c92c1a67bcbc7a6afb6c2a937616b8168a63f3fdff61ea4957f\",\"dweb:/ipfs/QmS3ZBTCr34uuVCXVRfuuvh5QRT9upruNhi222EjJ7tgJp\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAccessManager.sol\":{\"keccak256\":\"0x3a129298f50d5e1e8d46d91eb6aa40e18183b76f6983e13a0a1e5f43a8faedb6\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://e1a20642c110215a14f97d7cbd7048a19db9b9500b020b17b96138406ab6ab07\",\"dweb:/ipfs/QmRbrcJjQzGnz7T6KYCpZYtDYpx6id2KSDis7DPQhye1Zr\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAuthority.sol\":{\"keccak256\":\"0xd7b800fcca190ec8030b5d5792d7b5e6de3213ab322ada322e905540c58edd3b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b0d5da4f1aa7120b6fac945df72ff3661b0d1ee9bc175023ec29cecc6324c76b\",\"dweb:/ipfs/QmPDSsk9WcVwx4Je1t59txPUzh7si4Hnhu11VPjrTwQFPL\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1271.sol\":{\"keccak256\":\"0x67ddf13274cfd1dd994552801d8e2f67a32e2301d6680d7bb2eda99a7feff5eb\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://137e025f914ff2d56889b68629337b5f4dc4cba181cd0a3ec42a2e0cdf1d396a\",\"dweb:/ipfs/QmaVBNddWRuukyYZKAKDsvDZ64JWGCiMmF95cktsfH9muM\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1363.sol\":{\"keccak256\":\"0xcef3dfbf36b24b3d0bd209f8e1869f4c86287878240f66e651b122d26448fcc3\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ebc799e73eaf8a32c7be984f422f5b237e4b36277251968c60f74b282ecd1c91\",\"dweb:/ipfs/QmczzYkjSv93ZtPswneWbYSjkd4LEbhkg8iB4ZATvCEfCz\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC165.sol\":{\"keccak256\":\"0x71f27f20e8998b0d0266a5b5a9a73346baf513c98f7fe941d13f293c6f5f30fa\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8a810b05b2727a18024c91842beb4a65c6785d477c931a0e679fedba4963f73c\",\"dweb:/ipfs/QmdWk9H4YuKU9M86VsZD1syn4SMbVJCvoRGRwn74gLPRLG\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC20.sol\":{\"keccak256\":\"0x742c788bf2723742350a299027925399eb5b1da6b4971af846aabe742f7ce9fa\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://3a001c31d79f8df22a8b8111c728ab6719c516391e7687a16648c84242c3641b\",\"dweb:/ipfs/QmT7uM2J8pPKUjJJzVNYQiswd4eG6AU1CWDecCWdHrm3oz\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC20Metadata.sol\":{\"keccak256\":\"0x877f2cab8e4dfa6174d0177f04181319da118a7e367493ad7c68ee4cb8be7205\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c368c7a1eec4c3a6ae815e775f9bdbdd0130ad0c0b09447e9b9d56a2a4cafe2f\",\"dweb:/ipfs/QmbbMtEf5ZY6ZpQKLsVvmsHLB7A639qnEiAqhjSP3k17tY\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC3156FlashBorrower.sol\":{\"keccak256\":\"0xd470da87c982da3f6be8555b63f10d66462054def9d7da20aae37c3ee3c96d58\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c76692163f771760363ff3001755a6e1331c0b25b23ddaf5e072c0ed67f4b5cc\",\"dweb:/ipfs/QmXhYb6dwmoGq1ZcGfbuC5RaYFaDLG3FdqhHC4GqNe75DP\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC3156FlashLender.sol\":{\"keccak256\":\"0xbf67f5abbdb40a69d887f34bb9c578945c4d80ea5566264a16165bf49d06665b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6e325477bf279e74e4c4d13d5014a60697f35d20134ce424970f2336a7740423\",\"dweb:/ipfs/QmVrthF7KY6kp2RXrfiCZk9uZwPYHdPCqgiPpDeShJWu3z\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC4626.sol\":{\"keccak256\":\"0x085fcdfdf42d0092040e702303f54f9a0a3540bf25921588f0c44f2a870485df\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://cb8e63b28c91aaa8c5c6e393c39d53ced9868128ce60f8a0d38d57f7eebfa59f\",\"dweb:/ipfs/QmNfU4XSGnv8eD5UREt7Rs5TiLT2iVGd2CWpka3brngmRT\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC5267.sol\":{\"keccak256\":\"0x473d635a93adf200d4ec9ef1cb3ba9d33230d546fa0eb8ab95e6ed5a461da5d9\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://28dd2f7722f144efa18ad2797c744d214e02495f948d4d73b354ef049a6f813f\",\"dweb:/ipfs/QmeSyAoJk1FuS6F7MzJj6dvnqd6jNz6pNP2WjjLPhDLHdg\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC7913.sol\":{\"keccak256\":\"0xfa287c745741ef58af71e1068ebf9771fe55bc17c9efe39517d942a005744f24\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://78a7f7ab52e2ea38fb0f79ad786bb575af5e6a60a44a31bef37fbdeffd88330f\",\"dweb:/ipfs/QmZSiVgsapHHmQspCYDVGjayZANcvct4m2i65QdC2N3VGU\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/IERC20.sol\":{\"keccak256\":\"0xaa5c002dccc71cf9d6dd92a9fa87f205f32b0b9204303c442d567bfcb832d69d\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f17355804cadb61737c6d7ebf9539cd27eacd8a9099ffe711ce9dc0a2dd07442\",\"dweb:/ipfs/QmSVBcaVaaC9SxVsYsmfY1U3du3inqbNGPEpcMY4KkRrrj\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/extensions/IERC20Metadata.sol\":{\"keccak256\":\"0x090e3e7ffd747b5546cb7033e5425ec7fc8813da81f8bee455318fd8af5cc3a0\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://423facd62c0103f6810c7b43c1cf3002e8728a9e3aa57c32c46d100137a6f2ae\",\"dweb:/ipfs/QmPcMF3srsURFQRpQNCC5ALv8eGVFeupK8TYirBNTWVC8b\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/utils/SafeERC20.sol\":{\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8150ceb4ac947e8a442b2a9c017e01e880b2be2dd958f1fa9bc405f4c5a86508\",\"dweb:/ipfs/QmbcBmFX66AY6Kbhnd5gx7zpkgqnUafo43XnmayAM7zVdB\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Bytes.sol\":{\"keccak256\":\"0xee79e30c45319d56e7536317e1776686ec2d475795a27c3f2ac7e9c2f4edef7f\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://d0952f3c09421d8b2b3896b4789ad655a114b9206365b5363c1dd0a75583997d\",\"dweb:/ipfs/QmQPemDMHjWhhLmazue7gHnZRYxcbz9nbz4pKcC7ioSFyz\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Panic.sol\":{\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c6a5ff4f9fd8649b7ee20800b7fa387d3465bd77cf20c2d1068cd5c98e1ed57a\",\"dweb:/ipfs/QmVSaVJf9FXFhdYEYeCEfjMVHrxDh5qL4CGkxdMWpQCrqG\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Strings.sol\":{\"keccak256\":\"0x72d89c30d5c7c7f7923677b3738ceffe5a5671f885b4637badd0084c3f438213\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://15ad622659ea59783478bc73db26d57a74f400aef716a6478613919e45bd4b71\",\"dweb:/ipfs/QmPcaMREGhoehgMhY9s6BUrsVoK7F6YNU1xkG4VFe5yXjT\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/ECDSA.sol\":{\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8e25e4bdb7ae1f21d23bfee996e22736fc0ab44cfabedac82a757b1edc5623b9\",\"dweb:/ipfs/QmQdWQvB6JCP9ZMbzi8EvQ1PTETqkcTWrbcVurS7DKpa5n\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/MessageHashUtils.sol\":{\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b16d45febff462bafd8a5669f904796a835baf607df58a8461916d3bf4f08c59\",\"dweb:/ipfs/QmU2eJFpjmT4vxeJWJyLeQb8Xht1kdB8Y6MKLDPFA9WPux\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/SignatureChecker.sol\":{\"keccak256\":\"0x60da29c52e83ab33d9335cd153b7ef333d1758731eb5a600d13228a5ea30a704\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f9d21b7b68fc9b5406d8e762aaef2d4f3d06de774b37486555404919394a6b35\",\"dweb:/ipfs/QmQZYwwhyZyYfmcKKeLm6g7CBb8tF42XUVXE9mvywLnUJQ\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/introspection/IERC165.sol\":{\"keccak256\":\"0x2820b23a27421cbb9be0239e2210efbcdb73c3224e1a48acb7daff8d7d26964f\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://a00d4c01544a03232adb233c3e82d1b1eb82bde78df17f05fd56232f2773bd23\",\"dweb:/ipfs/QmZ9tPFfYYMdc3PCJPcAWCdvJ3Gt646MJxk2RZ3D9tjeZN\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/Math.sol\":{\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6c5fab4970634f9ab9a620983dc1c8a30153981a0b1a521666e269d0a11399d3\",\"dweb:/ipfs/QmVRnBC575MESGkEHndjujtR7qub2FzU9RWy9eKLp4hPZB\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/SafeCast.sol\":{\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b1d578337048cad08c1c03041cca5978eff5428aa130c781b271ad9e5566e1f8\",\"dweb:/ipfs/QmPFKL2r9CBsMwmUqqdcFPfHZB2qcs9g1HDrPxzWSxomvy\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/SignedMath.sol\":{\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://db5fbb3dddd8b7047465b62575d96231ba8a2774d37fb4737fbf23340fabbb03\",\"dweb:/ipfs/QmVUSvooZKEdEdap619tcJjTLcAuH6QBdZqAzWwnAXZAWJ\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/access/manager/AccessManagedUpgradeable.sol\":{\"keccak256\":\"0xafc6430a5a632a57bf0e1596dccdad8f208f449cfc340878dc1789e5f5b570d5\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1935bb38eac62a468fdc3f00174e4cb28b476668895ddfea5e0bcf56297b8145\",\"dweb:/ipfs/QmVmSMB2tykT9t5ZoMkREn2zNzYtK2ufNdxRYo3B7MLvVT\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/proxy/utils/Initializable.sol\":{\"keccak256\":\"0xdb4d24ee2c087c391d587cd17adfe5b3f9d93b3110b1388c2ab6c7c0ad1dcd05\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ab7b6d5b9e2b88176312967fe0f0e78f3d9a1422fa5e4b64e2440c35869b5d08\",\"dweb:/ipfs/QmXKYWWyzcLg1B2k7Sb1qkEXgLCYfXecR9wYW5obRzWP1Q\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/ContextUpgradeable.sol\":{\"keccak256\":\"0xdbef5f0c787055227243a7318ef74c8a5a1108ca3a07f2b3a00ef67769e1e397\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://08e39f23d5b4692f9a40803e53a8156b72b4c1f9902a88cd65ba964db103dab9\",\"dweb:/ipfs/QmPKn6EYDgpga7KtpkA8wV2yJCYGMtc9K4LkJfhKX2RVSV\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/PausableUpgradeable.sol\":{\"keccak256\":\"0xa6bf6b7efe0e6625a9dcd30c5ddf52c4c24fe8372f37c7de9dbf5034746768d5\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8c353ee3705bbf6fadb84c0fb10ef1b736e8ca3ca1867814349d1487ed207beb\",\"dweb:/ipfs/QmcugaPssrzGGE8q4YZKm2ZhnD3kCijjcgdWWg76nWt3FY\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/ReentrancyGuardUpgradeable.sol\":{\"keccak256\":\"0x361126a17677994081cd9cb69c3f50cffff6e920d25cb7e428acdb1ae41d1866\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://19ae787a7dd001269cd60a394b1a5261b78925a0fc3a6f927beb2986a9aa56cf\",\"dweb:/ipfs/QmYLfXiuKmcRgTDBEDXMMjXU8t6JxsspUmjxYzqWS55oEv\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/cryptography/EIP712Upgradeable.sol\":{\"keccak256\":\"0xba34a957324b4b1cb867111b948afc0cda72f5e9fdc7cb9b9b7bfeb0c2ad4edb\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://214590a0ca86c1209ef46f240c06ea1b9eb64e55bc98c2e3efc470fb682002f0\",\"dweb:/ipfs/Qme7wm5XTn8U3Xmn35DtpXw817888Drjm9YhJP2vQAunqV\"]},\"dependencies/core-v2-staging/src/interfaces/IPrincipalToken.sol\":{\"keccak256\":\"0xcb0a909e32a422ae2d9fb36f8664555d82cc6d602cd9584a8f2a577a834122f4\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://c85ec7286448237ad3a0214983d92f64f2c4640caf484a72914fc794441df1d8\",\"dweb:/ipfs/QmY5dGHStJVRmTkErDLrAW53akHQYZ4iSebJDXahFP2jyE\"]},\"dependencies/core-v2-staging/src/interfaces/IRegistry.sol\":{\"keccak256\":\"0x773e8224f8d8d7f5cfe89904c653ea1f1594506f0826b1735c6ed8553c517ebc\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://2beb9308d709f19135019ab138f8352561657c09f403354f2a86a5432f4f8ed6\",\"dweb:/ipfs/Qmb9fnNuDSLF5iURLeKCaLAWHWDuLpe2e6XMWCZBkd4d2Y\"]},\"dependencies/core-v2-staging/src/libraries/LogExpMath.sol\":{\"keccak256\":\"0x83fa012405dacb88992aa6653d8cf1fe6a00def6abd09e715c79f7a5a5a8fe74\",\"license\":\"GPL-3.0-or-later\",\"urls\":[\"bzz-raw://355bc2a9afcc3a44a90223ab6f42cbdf71722d7ab145ce429c5406052530fba5\",\"dweb:/ipfs/QmUSPm8tkEJ275eLQ7MP9AWcxs1BMtyreeZyFGK1eD9GEL\"]},\"dependencies/core-v2-staging/src/libraries/RayMath.sol\":{\"keccak256\":\"0xeb628b5cf03604856852b140401593daefc51cde6b426f2bccb7b21a4a6f3bff\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://0d0eb1f485646176a868b379fd445c06ce97d9ed78809660428484dbca8f943e\",\"dweb:/ipfs/QmWHgYkWbwRACsfhriTwRv3sp1BZ28UobXSHWfQ62WouY7\"]},\"src/LimitOrderEngine.sol\":{\"keccak256\":\"0xc74942259199aff0cc54624b90a1eb48004b3a3650dc3552be2e49350204f5b0\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://d59253db9eb3cd08941946dee5b9f02823ab3c2b2bc0ccf5304123d0e01ab1cf\",\"dweb:/ipfs/QmaNJzuhk4N3Nqqu9YuhfaA7yAY5pPFBgk5Z9ju3CacaP8\"]},\"src/NonceManager.sol\":{\"keccak256\":\"0x8bb26a9a69b686e2ee05da2ff9e6e89507755098faa08f927a4398d150ff4dd3\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f98091760d245ebe3198dcd407a26e50bb3f450b16ac65acd157a88204c1804d\",\"dweb:/ipfs/QmTDD44RtnjdGvS2KxNgsvdtjm6yxUG5o4fUc4s5C7ZXga\"]},\"src/interfaces/ILimitOrderEngine.sol\":{\"keccak256\":\"0x8441b2179f9abf02d9be2132f772ae3ef60667c9e5b57f928eed3040f376f948\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://85322926f9db326269ab22e5c6605ac9e908e233c8a909c3a607d93460a20271\",\"dweb:/ipfs/QmPGWwWScTmakrBs3L6wxcBRo9o7TYNxSWKnyrhExF8wxN\"]},\"src/interfaces/INonce.sol\":{\"keccak256\":\"0x6f5e9a88242928d51e57f9c431efd1505b8e68dfeb6e91b4828ddd7a4e0c6395\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://1422126a0c945b06c91c25e4fd9d2335dca877e0e21b223b2aa3bd5a39176f24\",\"dweb:/ipfs/QmZ95i57YmQUcdNxTkRdcWPB7x6XCZEanNemLBMfc3gkjK\"]},\"src/libraries/LimitOrderPricingLibrary.sol\":{\"keccak256\":\"0xd43e1f38dd029e0a679aec7a9bde5f9ad30e73530197ffe4796504f28345f9d1\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://41fb0bf1ba630a79b4c28ede794f397df5a609ef3952d06083df66336dce894d\",\"dweb:/ipfs/QmakeKmTA1FjUfq25SU7jCicNExqCEK14MRk2kwX9jkyEZ\"]},\"src/libraries/PricingLibrary.sol\":{\"keccak256\":\"0x16fa09df7a72b06ef4d2bdfac079c334c8ea77ae6d248ba695e3903d10de8ac9\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://ddfbae13dbedd763e4bfa8f087c9f8c1b383ce8cb1c22ec645337a14f1374d4e\",\"dweb:/ipfs/QmYBrnfeHjMKqRM9aeJDteGv1mzkbiEUMANTykvi3kxNR2\"]}},\"version\":1}",
+  "metadata": {
+    "compiler": {
+      "version": "0.8.28+commit.7893614a"
+    },
+    "language": "Solidity",
+    "output": {
+      "abi": [
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "authority",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "AccessManagedInvalidAuthority"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "caller",
+              "type": "address"
+            },
+            {
+              "internalType": "uint32",
+              "name": "delay",
+              "type": "uint32"
+            }
+          ],
+          "type": "error",
+          "name": "AccessManagedRequiredDelay"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "caller",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "AccessManagedUnauthorized"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "orderId",
+              "type": "bytes32"
+            }
+          ],
+          "type": "error",
+          "name": "AlreadyFilled"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "EnforcedPause"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "ExpectedPause"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "FeeGreaterThanMaxValue"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "IncompatibleOrderBatch"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "InsufficientFunds"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "InvalidBatchParams"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "InvalidInitialization"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "InvalidOrderForPreSign"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "InvalidOrderType"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "MaxTakingExceeded"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "NegativeImpliedRate"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "NoValidOrder"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "NotInitializing"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "NotMaker"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "NotRouter"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "orderHash",
+              "type": "bytes32"
+            }
+          ],
+          "type": "error",
+          "name": "OrderAlreadyRegistered"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "orderId",
+              "type": "bytes32"
+            }
+          ],
+          "type": "error",
+          "name": "OrderNotExisting"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "ReentrancyGuardReentrantCall"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "bits",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            }
+          ],
+          "type": "error",
+          "name": "SafeCastOverflowedUintDowncast"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "token",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "SafeERC20FailedOperation"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "authority",
+              "type": "address",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "AuthorityUpdated",
+          "anonymous": false
+        },
+        {
+          "inputs": [],
+          "type": "event",
+          "name": "EIP712DomainChanged",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "newFeeRecipient",
+              "type": "address",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "FeeRecipientUpdated",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint64",
+              "name": "version",
+              "type": "uint64",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Initialized",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "previousLimitOrderFee",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "newLimitOrderFee",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "LimitOrderFeeChange",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "maker",
+              "type": "address",
+              "indexed": true
+            },
+            {
+              "internalType": "uint256",
+              "name": "oldNonce",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "newNonce",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "NonceIncreased",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "maker",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "bytes32",
+              "name": "orderHash",
+              "type": "bytes32",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "OrderCanceled",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "orderHash",
+              "type": "bytes32",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "actualMaking",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "OrderFilled",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "orderHash",
+              "type": "bytes32",
+              "indexed": true
+            },
+            {
+              "internalType": "address",
+              "name": "maker",
+              "type": "address",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "OrderPreSigned",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Paused",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "newRouter",
+              "type": "address",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "RouterUpdated",
+          "anonymous": false
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "Unpaused",
+          "anonymous": false
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "MAX_LIMIT_ORDER_FEE",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint8",
+              "name": "amount",
+              "type": "uint8"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "advanceNonce"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "authority",
+          "outputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "struct ILimitOrderEngine.Order[]",
+              "name": "orders",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "salt",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "expiry",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "nonce",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "enum ILimitOrderEngine.OrderType",
+                  "name": "orderType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "address",
+                  "name": "pt",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "maker",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "receiver",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "makingAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "impliedRate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "cancelBatch"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "struct ILimitOrderEngine.Order",
+              "name": "order",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "salt",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "expiry",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "nonce",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "enum ILimitOrderEngine.OrderType",
+                  "name": "orderType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "address",
+                  "name": "pt",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "maker",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "receiver",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "makingAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "impliedRate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "cancelSingle"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "eip712Domain",
+          "outputs": [
+            {
+              "internalType": "bytes1",
+              "name": "fields",
+              "type": "bytes1"
+            },
+            {
+              "internalType": "string",
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "version",
+              "type": "string"
+            },
+            {
+              "internalType": "uint256",
+              "name": "chainId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "verifyingContract",
+              "type": "address"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "salt",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "extensions",
+              "type": "uint256[]"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "feeRecipient",
+          "outputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "struct ILimitOrderEngine.FillOrderParams[]",
+              "name": "params",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "struct ILimitOrderEngine.Order",
+                  "name": "order",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "uint256",
+                      "name": "salt",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "expiry",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "nonce",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "enum ILimitOrderEngine.OrderType",
+                      "name": "orderType",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "pt",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "maker",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "receiver",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "makingAmount",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "impliedRate",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "signature",
+                  "type": "bytes"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "makingAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "maxTaking",
+                  "type": "uint256"
+                }
+              ]
+            },
+            {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "fillOrders"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "getLimitOrderFee",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "struct ILimitOrderEngine.Order",
+              "name": "order",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "salt",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "expiry",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "nonce",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "enum ILimitOrderEngine.OrderType",
+                  "name": "orderType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "address",
+                  "name": "pt",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "maker",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "receiver",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "makingAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "impliedRate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "hashOrder",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "increaseNonce"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "_registry",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "_router",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "_initialAuthority",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "initialize"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isConsumingScheduledOp",
+          "outputs": [
+            {
+              "internalType": "bytes4",
+              "name": "",
+              "type": "bytes4"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "nonce",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "makerAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "makerNonce",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "nonceEquals",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32[]",
+              "name": "orderHashes",
+              "type": "bytes32[]"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "orderStatuses",
+          "outputs": [
+            {
+              "internalType": "uint256[]",
+              "name": "remainings",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "filledAmounts",
+              "type": "uint256[]"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "bytes32[]",
+              "name": "orderHashes",
+              "type": "bytes32[]"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "orderStatusesRaw",
+          "outputs": [
+            {
+              "internalType": "uint256[]",
+              "name": "remainingsRaw",
+              "type": "uint256[]"
+            },
+            {
+              "internalType": "uint256[]",
+              "name": "filledAmounts",
+              "type": "uint256[]"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "pause"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "paused",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "struct ILimitOrderEngine.Order[]",
+              "name": "orders",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "salt",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "expiry",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "nonce",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "enum ILimitOrderEngine.OrderType",
+                  "name": "orderType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "address",
+                  "name": "pt",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "maker",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "receiver",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "makingAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "impliedRate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "preSignBatch"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "struct ILimitOrderEngine.Order",
+              "name": "order",
+              "type": "tuple",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "salt",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "expiry",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "nonce",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "enum ILimitOrderEngine.OrderType",
+                  "name": "orderType",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "address",
+                  "name": "pt",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "maker",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "receiver",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "makingAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "impliedRate",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "preSignSingle"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "registry",
+          "outputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "router",
+          "outputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "newAuthority",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "setAuthority"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "_limitOrderFee",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "setLimitOrderFee"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "newRouter",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "setRouter"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "receiver",
+              "type": "address"
+            },
+            {
+              "internalType": "struct ILimitOrderEngine.FillOrderParams[]",
+              "name": "params",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "struct ILimitOrderEngine.Order",
+                  "name": "order",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "uint256",
+                      "name": "salt",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "expiry",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "nonce",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "enum ILimitOrderEngine.OrderType",
+                      "name": "orderType",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "pt",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "maker",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "receiver",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "makingAmount",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "impliedRate",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "signature",
+                  "type": "bytes"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "makingAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "maxTaking",
+                  "type": "uint256"
+                }
+              ]
+            },
+            {
+              "internalType": "struct ILimitOrderEngine.OrderResult[]",
+              "name": "validatedResults",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "actualTaking",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "actualMaking",
+                  "type": "uint256"
+                }
+              ]
+            },
+            {
+              "internalType": "address",
+              "name": "takerToken",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalTaking",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalFees",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "transferPostValidation"
+        },
+        {
+          "inputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "unpause"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "struct ILimitOrderEngine.FillOrderParams[]",
+              "name": "params",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "struct ILimitOrderEngine.Order",
+                  "name": "order",
+                  "type": "tuple",
+                  "components": [
+                    {
+                      "internalType": "uint256",
+                      "name": "salt",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "expiry",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "nonce",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "enum ILimitOrderEngine.OrderType",
+                      "name": "orderType",
+                      "type": "uint8"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "pt",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "maker",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "address",
+                      "name": "receiver",
+                      "type": "address"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "makingAmount",
+                      "type": "uint256"
+                    },
+                    {
+                      "internalType": "uint256",
+                      "name": "impliedRate",
+                      "type": "uint256"
+                    }
+                  ]
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "signature",
+                  "type": "bytes"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "makingAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "maxTaking",
+                  "type": "uint256"
+                }
+              ]
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "validateOrdersAndUpdateStatus",
+          "outputs": [
+            {
+              "internalType": "struct ILimitOrderEngine.OrderResult[]",
+              "name": "validatedResults",
+              "type": "tuple[]",
+              "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "actualTaking",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "actualMaking",
+                  "type": "uint256"
+                }
+              ]
+            },
+            {
+              "internalType": "address",
+              "name": "takerToken",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalTaking",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalFees",
+              "type": "uint256"
+            }
+          ]
+        }
+      ],
+      "devdoc": {
+        "kind": "dev",
+        "methods": {
+          "advanceNonce(uint8)": {
+            "params": {
+              "amount": "The amount by which to advance the nonce"
+            }
+          },
+          "authority()": {
+            "details": "Returns the current authority."
+          },
+          "cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])": {
+            "details": "Loops through orders and cancels each one.",
+            "params": {
+              "orders": "Array of orders to cancel."
+            }
+          },
+          "cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": {
+            "details": "Sets order status as filled and emits an event.",
+            "params": {
+              "order": "The order to cancel."
+            }
+          },
+          "eip712Domain()": {
+            "details": "returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
+          },
+          "fillOrders(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],bytes)": {
+            "details": "Must be called by the authorized router, which has already transferred the      taker input token to this contract before the call.All orders in the batch must share the same PT and a compatible OrderType.",
+            "params": {
+              "data": "ABI-encoded address of the taker's input token.",
+              "params": "Array of FillOrderParams containing order details and fill amounts.",
+              "receiver": "Address that receives the taker's output tokens (and any dust)."
+            }
+          },
+          "getLimitOrderFee()": {
+            "returns": {
+              "_0": "The current protocol limit-order fee in 18-decimal WAD."
+            }
+          },
+          "hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": {
+            "params": {
+              "order": "The order to hash"
+            },
+            "returns": {
+              "_0": "The order's hash as bytes32"
+            }
+          },
+          "increaseNonce()": {
+            "details": "Calls `advanceNonce(1)` internally"
+          },
+          "isConsumingScheduledOp()": {
+            "details": "Returns true only in the context of a delayed restricted call, at the moment that the scheduled operation is being consumed. Prevents denial of service for delayed restricted calls in the case that the contract performs attacker controlled calls."
+          },
+          "nonceEquals(address,uint256)": {
+            "params": {
+              "makerAddress": "The address of the maker",
+              "makerNonce": "The nonce to check against"
+            },
+            "returns": {
+              "_0": "result True if `makerAddress` has the specified nonce, otherwise false"
+            }
+          },
+          "orderStatuses(bytes32[])": {
+            "details": "Adjusts raw remaining values by subtracting one to confirm order existence",
+            "params": {
+              "orderHashes": "Array of order hashes to query"
+            },
+            "returns": {
+              "filledAmounts": "Filled amounts for each order",
+              "remainings": "Processed remaining amounts for each order"
+            }
+          },
+          "orderStatusesRaw(bytes32[])": {
+            "params": {
+              "orderHashes": "Array of order hashes to query"
+            },
+            "returns": {
+              "filledAmounts": "Filled amounts for each order",
+              "remainingsRaw": "Raw remaining amounts for each order"
+            }
+          },
+          "paused()": {
+            "details": "Returns true if the contract is paused, and false otherwise."
+          },
+          "preSignBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])": {
+            "details": "Loops through orders and pre-signs each one. Reverts if any order fails its checks.",
+            "params": {
+              "orders": "Array of orders to pre-sign."
+            }
+          },
+          "preSignSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": {
+            "details": "Allows fillers to skip EIP-712 signature verification for this order. The caller must be      the order's maker, the order must pass basic requirements (expiry/maturity/nonce), and the      order must not already exist (no prior fill, presign, or cancellation).",
+            "params": {
+              "order": "The order to pre-sign."
+            }
+          },
+          "setAuthority(address)": {
+            "details": "Transfers control to a new authority. The caller must be the current authority."
+          },
+          "setLimitOrderFee(uint256)": {
+            "details": "Restricted to the access manager. Reverts with `FeeGreaterThanMaxValue` if the new      fee exceeds `MAX_LIMIT_ORDER_FEE`.",
+            "params": {
+              "_limitOrderFee": "The new fee value in 18-decimal WAD (e.g. 1e16 = 1%)."
+            }
+          },
+          "setRouter(address)": {
+            "details": "This function allows an authorized entity to change the router contract.",
+            "params": {
+              "_newRouter": "The new router contract address."
+            }
+          },
+          "transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256,uint256)": {
+            "details": "Must be called by the authorized router after `validateOrdersAndUpdateStatus` and      after the router has transferred the taker input token to this contract.",
+            "params": {
+              "params": "Order parameters (used to route maker payments and derive PT address).",
+              "receiver": "Address that receives remaining tokens after maker settlement and fees.",
+              "takerToken": "Token owed to makers and fee recipient.",
+              "totalFees": "Total fees to send to feeRecipient.",
+              "totalTaking": "Total takerToken required (must be held by this contract).",
+              "validatedResults": "Results returned by `validateOrdersAndUpdateStatus`."
+            }
+          },
+          "validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[])": {
+            "details": "Must be called by the authorized router contract only.All orders must share the same PT and a compatible OrderType.",
+            "params": {
+              "params": "Array of FillOrderParams containing order details and fill amounts"
+            },
+            "returns": {
+              "takerToken": "Address of the token being taken from the taker",
+              "totalFees": "Aggregate fees collected from the transaction",
+              "totalTaking": "Aggregate takerToken required (fees included)",
+              "validatedResults": "Array of OrderResult structs with actual amounts per order"
+            }
+          }
+        },
+        "version": 1
+      },
+      "userdoc": {
+        "kind": "user",
+        "methods": {
+          "advanceNonce(uint8)": {
+            "notice": "Advances the nonce of the sender by a specified amount"
+          },
+          "cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])": {
+            "notice": "Cancels multiple orders in a batch."
+          },
+          "cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": {
+            "notice": "Cancels a single order."
+          },
+          "feeRecipient()": {
+            "notice": "=== Getters ==="
+          },
+          "fillOrders(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],bytes)": {
+            "notice": "Fills orders end-to-end: validates, pulls maker funds, handles optional         protocol deposit/withdraw, settles makers, collects fees, and returns         remaining balances to the receiver."
+          },
+          "getLimitOrderFee()": {
+            "notice": "Retrieves the current limit-order fee."
+          },
+          "hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": {
+            "notice": "Computes a unique hash for an order"
+          },
+          "increaseNonce()": {
+            "notice": "Advances the nonce of the sender by one"
+          },
+          "nonce(address)": {
+            "notice": "Returns the current nonce for a given address"
+          },
+          "nonceEquals(address,uint256)": {
+            "notice": "Checks if a given nonce matches the expected nonce for a maker"
+          },
+          "orderStatuses(bytes32[])": {
+            "notice": "Gets processed order statuses"
+          },
+          "orderStatusesRaw(bytes32[])": {
+            "notice": "Gets raw remaining and filled amounts for orders"
+          },
+          "preSignBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256)[])": {
+            "notice": "Pre-signs multiple orders on-chain."
+          },
+          "preSignSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256))": {
+            "notice": "Pre-signs a single order on-chain by setting the remaining amount to makingAmount + 1."
+          },
+          "router()": {
+            "notice": "Retrieves the current router address."
+          },
+          "setLimitOrderFee(uint256)": {
+            "notice": "Updates the protocol limit-order fee."
+          },
+          "setRouter(address)": {
+            "notice": "Updates the router address."
+          },
+          "transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256,uint256)": {
+            "notice": "Settles validated orders: checks engine balance, pays makers, collects fees,         and sweeps remaining IBT/PT/YT to the receiver."
+          },
+          "validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256),bytes,uint256,uint256)[])": {
+            "notice": "Validates orders, updates their status, and calculates aggregate totals."
+          }
+        },
+        "version": 1
       }
-   ],
-   "bytecode":{
-      "object":"0x608060405234801562000010575f80fd5b50620000216200002760201b60201c565b620001ae565b5f620000386200012b60201b60201c565b9050805f0160089054906101000a900460ff161562000083576040517ff92ee8a900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b67ffffffffffffffff8016815f015f9054906101000a900467ffffffffffffffff1667ffffffffffffffff1614620001285767ffffffffffffffff815f015f6101000a81548167ffffffffffffffff021916908367ffffffffffffffff1602179055507fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d267ffffffffffffffff6040516200011f919062000193565b60405180910390a15b50565b5f806200013d6200014660201b60201c565b90508091505090565b5f7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005f1b905090565b5f67ffffffffffffffff82169050919050565b6200018d816200016f565b82525050565b5f602082019050620001a85f83018462000182565b92915050565b616ac580620001bc5f395ff3fe608060405234801561000f575f80fd5b506004361061014b575f3560e01c80638456cb59116100c1578063c0c53b8b1161007a578063c0c53b8b14610380578063c0d786551461039c578063c53a0292146103b8578063cf6fc6e3146103c2578063e74b981b146103f2578063f887ea401461040e5761014b565b80638456cb59146102c757806384b0196e146102d15780638fb36037146102f5578063ada0844914610313578063bd8f11781461032f578063bf7e214f146103625761014b565b80635bd5f77d116101135780635bd5f77d146101f55780635c975abb1461022557806370ae92d21461024357806372c244a8146102735780637a9e5e4b1461028f5780637db458e5146102ab5761014b565b80630c0b8c9c1461014f57806319f752f61461018057806335ee3ffc1461019c5780633f4ba83a146101cd57806346904840146101d7575b5f80fd5b61016960048036038101906101649190614a1c565b61042c565b604051610177929190614b27565b60405180910390f35b61019a60048036038101906101959190615125565b610511565b005b6101b660048036038101906101b19190614a1c565b610853565b6040516101c4929190614b27565b60405180910390f35b6101d5610a4e565b005b6101df610a70565b6040516101ec91906151e3565b60405180910390f35b61020f600480360381019061020a91906151fc565b610a95565b60405161021c919061525b565b60405180910390f35b61022d610b08565b60405161023a919061528e565b60405180910390f35b61025d600480360381019061025891906152a7565b610b2a565b60405161026a91906152e1565b60405180910390f35b61028d60048036038101906102889190615330565b610b3e565b005b6102a960048036038101906102a491906152a7565b610c2f565b005b6102c560048036038101906102c0919061537e565b610d19565b005b6102cf610ec3565b005b6102d9610ee5565b6040516102ec9796959493929190615479565b60405180910390f35b6102fd610fee565b60405161030a9190615535565b60405180910390f35b61032d600480360381019061032891906155a3565b611027565b005b61034960048036038101906103449190615643565b611071565b6040516103599493929190615763565b60405180910390f35b61036a611746565b60405161037791906151e3565b60405180910390f35b61039a600480360381019061039591906157ad565b61177b565b005b6103b660048036038101906103b191906152a7565b6119f2565b005b6103c0611a90565b005b6103dc60048036038101906103d791906157fd565b611a9c565b6040516103e9919061528e565b60405180910390f35b61040c600480360381019061040791906152a7565b611ae4565b005b610416611b82565b60405161042391906151e3565b60405180910390f35b6060806104398484610853565b80925081935050505f5b8251811015610509575f6fffffffffffffffffffffffffffffffff168382815181106104725761047161583b565b5b6020026020010151036104d5578484828181106104925761049161583b565b5b905060200201356040517f84a19ff70000000000000000000000000000000000000000000000000000000081526004016104cc919061525b565b60405180910390fd5b60018382815181106104ea576104e961583b565b5b6020026020010181815103915081815250508080600101915050610443565b509250929050565b60655f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614610597576040517f9165520100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f5b83518110156107ae575f8482815181106105b6576105b561583b565b5b60200260200101516020015103156107a3575f8582815181106105dc576105db61583b565b5b60200260200101515f015190505f6105f382611ba7565b905061060481836101200151611ddc565b8073ffffffffffffffffffffffffffffffffffffffff166323b872dd8360a001518a8987815181106106395761063861583b565b5b6020026020010151602001516040518463ffffffff1660e01b815260040161066393929190615868565b6020604051808303815f875af115801561067f573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906106a391906158c7565b508473ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8360c001518886815181106106d8576106d761583b565b5b60200260200101515f01516040518363ffffffff1660e01b81526004016107009291906158f2565b6020604051808303815f875af115801561071c573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061074091906158c7565b507ffec331350fce78ba658e082a71da20ac9f8d798a99b3c79681c8440cbfe77e0761076b83610a95565b87858151811061077e5761077d61583b565b5b602002602001015160200151604051610798929190615919565b60405180910390a150505b806001019050610599565b508173ffffffffffffffffffffffffffffffffffffffff1663a9059cbb60665f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff16836040518363ffffffff1660e01b815260040161080b9291906158f2565b6020604051808303815f875af1158015610827573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061084b91906158c7565b505050505050565b6060805f8484905090508067ffffffffffffffff81111561087757610876614bc6565b5b6040519080825280602002602001820160405280156108a55781602001602082028036833780820191505090505b5092508067ffffffffffffffff8111156108c2576108c1614bc6565b5b6040519080825280602002602001820160405280156108f05781602001602082028036833780820191505090505b5091505f5b81811015610a45575f60675f8888858181106109145761091361583b565b5b9050602002013581526020019081526020015f206040518060400160405290815f82015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff1681526020015f820160109054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff16815250509050805f01518160200151816fffffffffffffffffffffffffffffffff169150806fffffffffffffffffffffffffffffffff169050868481518110610a0c57610a0b61583b565b5b60200260200101868581518110610a2657610a2561583b565b5b60200260200101828152508281525050505080806001019150506108f5565b50509250929050565b610a66610a59611e8c565b610a61611e93565b611e9f565b610a6e611fe6565b565b60665f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b5f610a9e6148e3565b829050610b007ff34603235044803a1065918322e607156b2ad4b7321677ede0e35900101dccf08285610120015180519060200120604051602001610ae593929190615a77565b60405160208183030381529060405280519060200120612054565b915050919050565b5f80610b1261206d565b9050805f015f9054906101000a900460ff1691505090565b5f602052805f5260405f205f915090505481565b5f8160ff165f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f2054610b8a9190615adb565b9050805f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f20819055503373ffffffffffffffffffffffffffffffffffffffff167fdc0537f71d06d3708f52baf4ddf6918b25f1a145ba08873de27485682b35cac18360ff1683610c149190615b0e565b83604051610c23929190615b41565b60405180910390a25050565b5f610c38611e8c565b9050610c42611746565b73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614610cb157806040517f068ca9d8000000000000000000000000000000000000000000000000000000008152600401610ca891906151e3565b60405180910390fd5b5f8273ffffffffffffffffffffffffffffffffffffffff163b03610d0c57816040517fc2f31e5e000000000000000000000000000000000000000000000000000000008152600401610d0391906151e3565b60405180910390fd5b610d1582612094565b5050565b3373ffffffffffffffffffffffffffffffffffffffff168160a0016020810190610d4391906152a7565b73ffffffffffffffffffffffffffffffffffffffff1614610d90576040517fb331e42100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f610da382610d9e90615b68565b610a95565b905060016fffffffffffffffffffffffffffffffff1660675f8381526020019081526020015f205f015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff1603610e3c57806040517fcee81443000000000000000000000000000000000000000000000000000000008152600401610e33919061525b565b60405180910390fd5b600160675f8381526020019081526020015f205f015f6101000a8154816fffffffffffffffffffffffffffffffff02191690836fffffffffffffffffffffffffffffffff1602179055507f35ab4a1a0e9bec7fd7ae164679b9cc00e6568e4db238d8055a75b1862f62ec2e3382604051610eb7929190615b7a565b60405180910390a15050565b610edb610ece611e8c565b610ed6611e93565b611e9f565b610ee361211b565b565b5f6060805f805f60605f610ef761218a565b90505f801b815f0154148015610f1257505f801b8160010154145b610f51576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610f4890615beb565b60405180910390fd5b610f596121b1565b610f6161224f565b46305f801b5f67ffffffffffffffff811115610f8057610f7f614bc6565b5b604051908082528060200260200182016040528015610fae5781602001602082028036833780820191505090505b507f0f0000000000000000000000000000000000000000000000000000000000000095949392919097509750975097509750975097505090919293949596565b5f80610ff86122ed565b9050805f0160149054906101000a900460ff16611018575f60e01b611021565b638fb3603760e01b5b91505090565b5f5b8282905081101561106c5761106183838381811061104a5761104961583b565b5b905060200281019061105c9190615c0d565b610d19565b806001019050611029565b505050565b60605f805f60655f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16146110fc576040517f9165520100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f8087875f8181106111115761111061583b565b5b90506020028101906111239190615c35565b805f01906111319190615c0d565b60600160208101906111439190615c5c565b90508787905067ffffffffffffffff81111561116257611161614bc6565b5b60405190808252806020026020018201604052801561119b57816020015b61118861497a565b8152602001906001900390816111805790505b5095505f5b888890508110156116fe575f8989838181106111bf576111be61583b565b5b90506020028101906111d19190615c35565b805f01906111df9190615c0d565b6111e890615b68565b90506111f381612314565b611209578361120190615c87565b9350506116f3565b5f61121382610a95565b90505f806fffffffffffffffffffffffffffffffff1660675f8481526020019081526020015f205f015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff16141590505f8115611339575f60016fffffffffffffffffffffffffffffffff1660675f8681526020019081526020015f205f015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff1614905080156112ea57876112de90615c87565b975050505050506116f3565b60675f8581526020019081526020015f205f015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff16915060018203915050611397565b5f6113718e8e888181106113505761134f61583b565b5b90506020028101906113629190615c35565b61136b90615cce565b856123cf565b90508061138e578761138290615c87565b975050505050506116f3565b8460e001519150505b5f6113ca828f8f898181106113af576113ae61583b565b5b90506020028101906113c19190615c35565b60400135612417565b9050808203915060405180604001604052806113e86001850161242d565b6fffffffffffffffffffffffffffffffff16815260200161144b8360675f8981526020019081526020015f205f0160109054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff160161242d565b6fffffffffffffffffffffffffffffffff1681525060675f8681526020019081526020015f205f820151815f015f6101000a8154816fffffffffffffffffffffffffffffffff02191690836fffffffffffffffffffffffffffffffff1602179055506020820151815f0160106101000a8154816fffffffffffffffffffffffffffffffff02191690836fffffffffffffffffffffffffffffffff1602179055509050506114f6614992565b6115008683612490565b825f0183602001828152508281525050508e8e888181106115245761152361583b565b5b90506020028101906115369190615c35565b606001358160200151825f015161154d9190615adb565b1115611585576040517fa28213a300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b8060200151815f01516115989190615adb565b8b6115a39190615adb565b9a5080602001518a6115b59190615adb565b99506040518060400160405280825f01518152602001838152508d88815181106115e2576115e161583b565b5b602002602001018190525061163c8f8f5f8181106116035761160261583b565b5b90506020028101906116159190615c35565b805f01906116239190615c0d565b608001602081019061163591906152a7565b8988612ab6565b611672576040517fffa07f1000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f73ffffffffffffffffffffffffffffffffffffffff168c73ffffffffffffffffffffffffffffffffffffffff16036116ec576116e98f8f898181106116bb576116ba61583b565b5b90506020028101906116cd9190615c35565b805f01906116db9190615c0d565b6116e490615b68565b612ca2565b9b505b5050505050505b8060010190506111a0565b5087879050820361173b576040517f9bc0260d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b505092959194509250565b5f806117506122ed565b9050805f015f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1691505090565b5f611784612f0d565b90505f815f0160089054906101000a900460ff161590505f825f015f9054906101000a900467ffffffffffffffff1690505f808267ffffffffffffffff161480156117cc5750825b90505f60018367ffffffffffffffff161480156117ff57505f3073ffffffffffffffffffffffffffffffffffffffff163b145b90508115801561180d575080155b15611844576040517ff92ee8a900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6001855f015f6101000a81548167ffffffffffffffff021916908367ffffffffffffffff1602179055508315611891576001855f0160086101000a81548160ff0219169083151502179055505b61189a86612f20565b61190e6040518060400160405280601c81526020017f53706563747261204c696d6974204f726465722050726f746f636f6c000000008152506040518060400160405280600181526020017f3100000000000000000000000000000000000000000000000000000000000000815250612f34565b8760665f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508660655f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555083156119e8575f855f0160086101000a81548160ff0219169083151502179055507fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d260016040516119df9190615d35565b60405180910390a15b5050505050505050565b611a0a6119fd611e8c565b611a05611e93565b611e9f565b8060655f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508073ffffffffffffffffffffffffffffffffffffffff167f7aed1d3e8155a07ccf395e44ea3109a0e2d6c9b29bbbe9f142d9790596f4dc8060405160405180910390a250565b611a9a6001610b3e565b565b5f815f808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205414905092915050565b611afc611aef611e8c565b611af7611e93565b611e9f565b8060665f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508073ffffffffffffffffffffffffffffffffffffffff167f7a7b5a0a132f9e0581eb8527f66eae9ee89c2a3e79d4ac7e41a1f1f4d48a7fc260405160405180910390a250565b60655f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b5f808260800151905060016004811115611bc457611bc3615940565b5b83606001516004811115611bdb57611bda615940565b5b03611c54578073ffffffffffffffffffffffffffffffffffffffff1663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015611c29573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611c4d9190615d62565b9150611dd6565b60026004811115611c6857611c67615940565b5b83606001516004811115611c7f57611c7e615940565b5b03611c905782608001519150611dd5565b60036004811115611ca457611ca3615940565b5b83606001516004811115611cbb57611cba615940565b5b03611d34578073ffffffffffffffffffffffffffffffffffffffff1663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015611d09573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611d2d9190615d62565b9150611dd4565b600480811115611d4757611d46615940565b5b83606001516004811115611d5e57611d5d615940565b5b03611dd3578073ffffffffffffffffffffffffffffffffffffffff166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa158015611dac573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611dd09190615d62565b91505b5b5b5b50919050565b5f81510315611e88575f805f805f805f87806020019051810190611e009190615e1a565b96509650965096509650965096508873ffffffffffffffffffffffffffffffffffffffff1663d505accf888888888888886040518863ffffffff1660e01b8152600401611e539796959493929190615ec6565b5f604051808303815f87803b158015611e6a575f80fd5b505af1158015611e7c573d5f803e3d5ffd5b50505050505050505050505b5050565b5f33905090565b365f8036915091509091565b5f611ea86122ed565b90505f80611edc611eb7611746565b873088885f90600492611ecc93929190615f3b565b90611ed79190615f8b565b612f4a565b9150915081611fde575f8163ffffffff161115611fa0576001835f0160146101000a81548160ff021916908315150217905550611f17611746565b73ffffffffffffffffffffffffffffffffffffffff166394c7d7ee8787876040518463ffffffff1660e01b8152600401611f5393929190616025565b5f604051808303815f87803b158015611f6a575f80fd5b505af1158015611f7c573d5f803e3d5ffd5b505050505f835f0160146101000a81548160ff021916908315150217905550611fdd565b856040517f068ca9d8000000000000000000000000000000000000000000000000000000008152600401611fd491906151e3565b60405180910390fd5b5b505050505050565b611fee612fde565b5f611ff761206d565b90505f815f015f6101000a81548160ff0219169083151502179055507f5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa61203c611e8c565b60405161204991906151e3565b60405180910390a150565b5f61206661206061301e565b8361302c565b9050919050565b5f7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300905090565b5f61209d6122ed565b905081815f015f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055507f2f658b440c35314f52658ea8a740e05b284cdc84dc9ae01e891f21b8933e7cad8260405161210f91906151e3565b60405180910390a15050565b61212361306c565b5f61212c61206d565b90506001815f015f6101000a81548160ff0219169083151502179055507f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258612172611e8c565b60405161217f91906151e3565b60405180910390a150565b5f7fa16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d100905090565b60605f6121bc61218a565b90508060020180546121cd90616082565b80601f01602080910402602001604051908101604052809291908181526020018280546121f990616082565b80156122445780601f1061221b57610100808354040283529160200191612244565b820191905f5260205f20905b81548152906001019060200180831161222757829003601f168201915b505050505091505090565b60605f61225a61218a565b905080600301805461226b90616082565b80601f016020809104026020016040519081016040528092919081815260200182805461229790616082565b80156122e25780601f106122b9576101008083540402835291602001916122e2565b820191905f5260205f20905b8154815290600101906020018083116122c557829003601f168201915b505050505091505090565b5f7ff3177357ab46d8af007ab3fdb9af81da189e1068fefdc0073dca88a2cab40a00905090565b5f42826020015111612328575f90506123ca565b42826080015173ffffffffffffffffffffffffffffffffffffffff1663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa158015612376573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061239a91906160b2565b116123a7575f90506123ca565b6123b98260a001518360400151611a9c565b6123c5575f90506123ca565b600190505b919050565b5f80835f015160a0015190505f813b90505f81036123fd576123f6828587602001516130ad565b925061240f565b61240c82858760200151613159565b92505b505092915050565b5f6124258284108484613278565b905092915050565b5f6fffffffffffffffffffffffffffffffff8016821115612488576080826040517f6dfcc65000000000000000000000000000000000000000000000000000000000815260040161247f929190616116565b60405180910390fd5b819050919050565b5f805f846060015190505f6125a9601261259b886101000151428a6080015173ffffffffffffffffffffffffffffffffffffffff1663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa1580156124f7573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061251b91906160b2565b6125259190615b0e565b8a6080015173ffffffffffffffffffffffffffffffffffffffff1663a1c5b3e16040518163ffffffff1660e01b8152600401602060405180830381865afa158015612572573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061259691906160b2565b613291565b61333590919063ffffffff16565b90505f6126306012886080015173ffffffffffffffffffffffffffffffffffffffff1663efd98dc26040518163ffffffff1660e01b8152600401602060405180830381865afa1580156125fe573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061262291906160b2565b61333590919063ffffffff16565b90505f61263c8861335e565b90505f90506001600481111561265557612654615940565b5b84600481111561266857612667615940565b5b036126f9575f826012600a61267d919061626c565b8561268891906162b6565b6126929190616324565b90506012600a6126a2919061626c565b81896126ae91906162b6565b6126b89190616324565b96505f82146126f357816012600a6126d0919061626c565b836126db9190615b0e565b896126e691906162b6565b6126f09190616324565b95505b50612aab565b6002600481111561270d5761270c615940565b5b8460048111156127205761271f615940565b5b036127be575f836012600a612735919061626c565b8461274091906162b6565b61274a9190616324565b90506012600a61275a919061626c565b818961276691906162b6565b6127709190616324565b96505f82146127b8576012600a612787919061626c565b6012600a612795919061626c565b836127a09190615b0e565b886127ab91906162b6565b6127b59190616324565b95505b50612aaa565b600360048111156127d2576127d1615940565b5b8460048111156127e5576127e4615940565b5b03612909575f8361287060128b6080015173ffffffffffffffffffffffffffffffffffffffff1663a1c5b3e16040518163ffffffff1660e01b8152600401602060405180830381865afa15801561283e573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061286291906160b2565b61333590919063ffffffff16565b61287a9190615b0e565b90505f836012600a61288c919061626c565b8361289791906162b6565b6128a19190616324565b90506012600a6128b1919061626c565b818a6128bd91906162b6565b6128c79190616324565b97505f831461290257816012600a6128df919061626c565b846128ea9190615b0e565b8a6128f591906162b6565b6128ff9190616324565b96505b5050612aa9565b60048081111561291c5761291b615940565b5b84600481111561292f5761292e615940565b5b03612a76575f836129ba60128b6080015173ffffffffffffffffffffffffffffffffffffffff1663a1c5b3e16040518163ffffffff1660e01b8152600401602060405180830381865afa158015612988573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906129ac91906160b2565b61333590919063ffffffff16565b6129c49190615b0e565b90505f816012600a6129d6919061626c565b856129e191906162b6565b6129eb9190616324565b90506012600a6129fb919061626c565b818a612a0791906162b6565b612a119190616324565b97505f8314612a6f57816012600a612a29919061626c565b846012600a612a38919061626c565b86612a439190615b0e565b8b612a4e91906162b6565b612a589190616324565b612a6291906162b6565b612a6c9190616324565b96505b5050612aa8565b6040517f688c176f00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5b5b5b505050509250929050565b5f8373ffffffffffffffffffffffffffffffffffffffff16826080015173ffffffffffffffffffffffffffffffffffffffff1614612af6575f9050612c9b565b60026004811115612b0a57612b09615940565b5b836004811115612b1d57612b1c615940565b5b1480612b4c5750600480811115612b3757612b36615940565b5b836004811115612b4a57612b49615940565b5b145b15612bc25760026004811115612b6557612b64615940565b5b82606001516004811115612b7c57612b7b615940565b5b1480612baf5750600480811115612b9657612b95615940565b5b82606001516004811115612bad57612bac615940565b5b145b15612bbd5760019050612c9b565b612c97565b60016004811115612bd657612bd5615940565b5b836004811115612be957612be8615940565b5b148015612c1e575060016004811115612c0557612c04615940565b5b82606001516004811115612c1c57612c1b615940565b5b145b15612c2c5760019050612c9b565b60036004811115612c4057612c3f615940565b5b836004811115612c5357612c52615940565b5b148015612c88575060036004811115612c6f57612c6e615940565b5b82606001516004811115612c8657612c85615940565b5b145b15612c965760019050612c9b565b5b5f90505b9392505050565b5f808260800151905060016004811115612cbf57612cbe615940565b5b83606001516004811115612cd657612cd5615940565b5b03612ce75782608001519150612f07565b60026004811115612cfb57612cfa615940565b5b83606001516004811115612d1257612d11615940565b5b03612d8b578073ffffffffffffffffffffffffffffffffffffffff1663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612d60573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612d849190615d62565b9150612f06565b60036004811115612d9f57612d9e615940565b5b83606001516004811115612db657612db5615940565b5b03612e2f578073ffffffffffffffffffffffffffffffffffffffff166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612e04573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612e289190615d62565b9150612f05565b600480811115612e4257612e41615940565b5b83606001516004811115612e5957612e58615940565b5b03612ed2578073ffffffffffffffffffffffffffffffffffffffff1663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612ea7573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612ecb9190615d62565b9150612f04565b6040517f688c176f00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5b5b5b50919050565b5f80612f176134f3565b90508091505090565b612f2861351c565b612f318161355c565b50565b612f3c61351c565b612f468282613570565b5050565b5f805f858585604051602401612f6293929190616354565b60405160208183030381529060405263b700961360e01b6020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff838183161783525050505090505f80525f60205260405f8251602084018a5afa15612fd4575f51925060205191508160201c15820291505b5094509492505050565b612fe6610b08565b61301c576040517f8dfc202b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b565b5f6130276135c1565b905090565b5f6040517f190100000000000000000000000000000000000000000000000000000000000081528360028201528260228201526042812091505092915050565b613074610b08565b156130ab576040517fd93c066500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b565b5f808473ffffffffffffffffffffffffffffffffffffffff163b03613144575f806130d88585613624565b50915091505f60038111156130f0576130ef615940565b5b81600381111561310357613102615940565b5b14801561313b57508573ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff16145b92505050613152565b61314f848484613159565b90505b9392505050565b5f805f8573ffffffffffffffffffffffffffffffffffffffff1685856040516024016131869291906163cb565b604051602081830303815290604052631626ba7e60e01b6020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff83818316178352505050506040516131d89190616433565b5f60405180830381855afa9150503d805f8114613210576040519150601f19603f3d011682016040523d82523d5f602084013e613215565b606091505b509150915081801561322957506020815110155b801561326d5750631626ba7e60e01b7bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19168180602001905181019061326b9190616449565b145b925050509392505050565b5f61328284613679565b82841802821890509392505050565b5f806301e133806012600a6132a6919061626c565b856132b191906162b6565b6132bb919061647d565b90505f6012600a6132cc919061626c565b90505f86826132db91906164e5565b90505f6132e782613684565b90505f6133098486846132fa9190616526565b613304919061647d565b613737565b90505f8185896133199190616526565b613323919061647d565b90508096505050505050509392505050565b5f8082601b6133449190615b0e565b600a613350919061626c565b905080840491505092915050565b5f8060655f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16635ab1bd536040518163ffffffff1660e01b8152600401602060405180830381865afa1580156133ca573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906133ee9190615d62565b90505f8173ffffffffffffffffffffffffffffffffffffffff166334b08c056040518163ffffffff1660e01b8152600401602060405180830381865afa15801561343a573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061345e91906160b2565b90505f42856080015173ffffffffffffffffffffffffffffffffffffffff1663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa1580156134af573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906134d391906160b2565b6134dd9190615b0e565b90506134e98282613d36565b9350505050919050565b5f7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005f1b905090565b613524613f93565b61355a576040517fd7e6bcf800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b565b61356461351c565b61356d81612094565b50565b61357861351c565b5f61358161218a565b9050828160020190816135949190616724565b50818160030190816135a69190616724565b505f801b815f01819055505f801b8160010181905550505050565b5f7f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f6135eb613fb1565b6135f3614027565b46306040516020016136099594939291906167f3565b60405160208183030381529060405280519060200120905090565b5f805f6041845103613664575f805f602087015192506040870151915060608701515f1a90506136568882858561409e565b955095509550505050613672565b5f600285515f1b9250925092505b9250925092565b5f8115159050919050565b5f8082136136c7576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016136be9061688e565b60405180910390fd5b8167016345785d8a0000670de0b6b3a7640000031280156136f9575067016345785d8a0000670de0b6b3a76400000182125b1561372657670de0b6b3a764000061371083614185565b8161371e5761371d6162f7565b5b059050613732565b61372f8261439d565b90505b919050565b5f7ffffffffffffffffffffffffffffffffffffffffffffffffdc702bd3a30fc00008212158015613771575068070c1cc73b00c800008213155b6137b0576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016137a7906168f6565b60405180910390fd5b5f8212156137e4576137c3825f03613737565b670de0b6b3a76400008002816137dc576137db6162f7565b5b059050613d31565b5f6806f05b59d3b20000008312613823576806f05b59d3b200000083039250770195e54c5dd42177f53a27172fa9ec630262827000000000905061385b565b6803782dace9d90000008312613855576803782dace9d9000000830392506b1425982cf597cd205cef7380905061385a565b600190505b5b6064830292505f68056bc75e2d63100000905068ad78ebc5ac6200000084126138ba5768ad78ebc5ac620000008403935068056bc75e2d631000006e01855144814a7ff805980ff00840008202816138b6576138b56162f7565b5b0590505b6856bc75e2d6310000008412613903576856bc75e2d6310000008403935068056bc75e2d631000006b02df0ab5a80a22c61ab5a7008202816138ff576138fe6162f7565b5b0590505b682b5e3af16b18800000841261394a57682b5e3af16b188000008403935068056bc75e2d63100000693f1fce3da636ea5cf850820281613946576139456162f7565b5b0590505b6815af1d78b58c4000008412613991576815af1d78b58c4000008403935068056bc75e2d63100000690127fa27722cc06cc5e282028161398d5761398c6162f7565b5b0590505b680ad78ebc5ac620000084126139d757680ad78ebc5ac62000008403935068056bc75e2d6310000068280e60114edb805d038202816139d3576139d26162f7565b5b0590505b68056bc75e2d631000008412613a1d5768056bc75e2d631000008403935068056bc75e2d63100000680ebc5fb41746121110820281613a1957613a186162f7565b5b0590505b6802b5e3af16b18800008412613a63576802b5e3af16b18800008403935068056bc75e2d631000006808f00f760a4b2db55d820281613a5f57613a5e6162f7565b5b0590505b68015af1d78b58c400008412613aa95768015af1d78b58c400008403935068056bc75e2d631000006806f5f1775788937937820281613aa557613aa46162f7565b5b0590505b5f68056bc75e2d6310000090505f8590508082019150600268056bc75e2d6310000087830281613adc57613adb6162f7565b5b0581613aeb57613aea6162f7565b5b0590508082019150600368056bc75e2d6310000087830281613b1057613b0f6162f7565b5b0581613b1f57613b1e6162f7565b5b0590508082019150600468056bc75e2d6310000087830281613b4457613b436162f7565b5b0581613b5357613b526162f7565b5b0590508082019150600568056bc75e2d6310000087830281613b7857613b776162f7565b5b0581613b8757613b866162f7565b5b0590508082019150600668056bc75e2d6310000087830281613bac57613bab6162f7565b5b0581613bbb57613bba6162f7565b5b0590508082019150600768056bc75e2d6310000087830281613be057613bdf6162f7565b5b0581613bef57613bee6162f7565b5b0590508082019150600868056bc75e2d6310000087830281613c1457613c136162f7565b5b0581613c2357613c226162f7565b5b0590508082019150600968056bc75e2d6310000087830281613c4857613c476162f7565b5b0581613c5757613c566162f7565b5b0590508082019150600a68056bc75e2d6310000087830281613c7c57613c7b6162f7565b5b0581613c8b57613c8a6162f7565b5b0590508082019150600b68056bc75e2d6310000087830281613cb057613caf6162f7565b5b0581613cbf57613cbe6162f7565b5b0590508082019150600c68056bc75e2d6310000087830281613ce457613ce36162f7565b5b0581613cf357613cf26162f7565b5b059050808201915060648468056bc75e2d6310000084860281613d1957613d186162f7565b5b050281613d2957613d286162f7565b5b059450505050505b919050565b5f808203613d4e57670de0b6b3a76400009050613f8d565b5f8303613d5d575f9050613f8d565b7f80000000000000000000000000000000000000000000000000000000000000008310613dbf576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401613db69061695e565b60405180910390fd5b5f83905068056bc75e2d631000007f400000000000000000000000000000000000000000000000000000000000000081613dfc57613dfb6162f7565b5b048310613e3e576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401613e35906169c6565b60405180910390fd5b5f8390505f8267016345785d8a0000670de0b6b3a764000003128015613e75575067016345785d8a0000670de0b6b3a76400000183125b15613edd575f613e8484614185565b9050670de0b6b3a764000083670de0b6b3a76400008381613ea857613ea76162f7565b5b070281613eb857613eb76162f7565b5b0583670de0b6b3a76400008381613ed257613ed16162f7565b5b050201915050613eeb565b81613ee78461439d565b0290505b670de0b6b3a76400008181613f0357613f026162f7565b5b059050807ffffffffffffffffffffffffffffffffffffffffffffffffdc702bd3a30fc000013158015613f3f575068070c1cc73b00c800008113155b613f7e576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401613f7590616a2e565b60405180910390fd5b613f8781613737565b93505050505b92915050565b5f613f9c612f0d565b5f0160089054906101000a900460ff16905090565b5f80613fbb61218a565b90505f613fc66121b1565b90505f81511115613fe257808051906020012092505050614024565b5f825f015490505f801b8114613ffd57809350505050614024565b7fc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a47093505050505b90565b5f8061403161218a565b90505f61403c61224f565b90505f815111156140585780805190602001209250505061409b565b5f826001015490505f801b81146140745780935050505061409b565b7fc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a47093505050505b90565b5f805f7f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0845f1c11156140da575f60038592509250925061417b565b5f6001888888886040515f81526020016040526040516140fd9493929190616a4c565b6020604051602081039080840390855afa15801561411d573d5f803e3d5ffd5b5050506020604051035190505f73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff160361416e575f60015f801b9350935093505061417b565b805f805f1b935093509350505b9450945094915050565b5f670de0b6b3a7640000820291505f6ec097ce7bc90715b34b9f100000000083016ec097ce7bc90715b34b9f100000000080850302816141c8576141c76162f7565b5b0590505f6ec097ce7bc90715b34b9f1000000000828302816141ed576141ec6162f7565b5b0590505f8290505f8190506ec097ce7bc90715b34b9f100000000083830281614219576142186162f7565b5b0591506003828161422d5761422c6162f7565b5b05810190506ec097ce7bc90715b34b9f100000000083830281614253576142526162f7565b5b05915060058281614267576142666162f7565b5b05810190506ec097ce7bc90715b34b9f10000000008383028161428d5761428c6162f7565b5b059150600782816142a1576142a06162f7565b5b05810190506ec097ce7bc90715b34b9f1000000000838302816142c7576142c66162f7565b5b059150600982816142db576142da6162f7565b5b05810190506ec097ce7bc90715b34b9f100000000083830281614301576143006162f7565b5b059150600b8281614315576143146162f7565b5b05810190506ec097ce7bc90715b34b9f10000000008383028161433b5761433a6162f7565b5b059150600d828161434f5761434e6162f7565b5b05810190506ec097ce7bc90715b34b9f100000000083830281614375576143746162f7565b5b059150600f8281614389576143886162f7565b5b058101905060028102945050505050919050565b5f670de0b6b3a76400008212156143da576143d182670de0b6b3a76400008002816143cb576143ca6162f7565b5b0561439d565b5f0390506148de565b5f670de0b6b3a7640000770195e54c5dd42177f53a27172fa9ec63026282700000000002831261443e57770195e54c5dd42177f53a27172fa9ec630262827000000000838161442c5761442b6162f7565b5b0592506806f05b59d3b2000000810190505b670de0b6b3a76400006b1425982cf597cd205cef7380028312614489576b1425982cf597cd205cef73808381614477576144766162f7565b5b0592506803782dace9d9000000810190505b6064810290506064830292506e01855144814a7ff805980ff008400083126144e7576e01855144814a7ff805980ff008400068056bc75e2d631000008402816144d5576144d46162f7565b5b05925068ad78ebc5ac62000000810190505b6b02df0ab5a80a22c61ab5a7008312614533576b02df0ab5a80a22c61ab5a70068056bc75e2d63100000840281614521576145206162f7565b5b0592506856bc75e2d631000000810190505b693f1fce3da636ea5cf850831261457b57693f1fce3da636ea5cf85068056bc75e2d63100000840281614569576145686162f7565b5b059250682b5e3af16b18800000810190505b690127fa27722cc06cc5e283126145c357690127fa27722cc06cc5e268056bc75e2d631000008402816145b1576145b06162f7565b5b0592506815af1d78b58c400000810190505b68280e60114edb805d0383126146095768280e60114edb805d0368056bc75e2d631000008402816145f7576145f66162f7565b5b059250680ad78ebc5ac6200000810190505b680ebc5fb41746121110831261464f57680ebc5fb4174612111068056bc75e2d6310000084028161463d5761463c6162f7565b5b05925068056bc75e2d63100000810190505b6808f00f760a4b2db55d8312614695576808f00f760a4b2db55d68056bc75e2d63100000840281614683576146826162f7565b5b0592506802b5e3af16b1880000810190505b6806f5f177578893793783126146db576806f5f177578893793768056bc75e2d631000008402816146c9576146c86162f7565b5b05925068015af1d78b58c40000810190505b6806248f33704b2866038312614720576806248f33704b28660368056bc75e2d6310000084028161470f5761470e6162f7565b5b05925067ad78ebc5ac620000810190505b6805c548670b9510e7ac8312614765576805c548670b9510e7ac68056bc75e2d63100000840281614754576147536162f7565b5b0592506756bc75e2d6310000810190505b5f68056bc75e2d63100000840168056bc75e2d63100000808603028161478e5761478d6162f7565b5b0590505f68056bc75e2d63100000828302816147ad576147ac6162f7565b5b0590505f8290505f81905068056bc75e2d63100000838302816147d3576147d26162f7565b5b059150600382816147e7576147e66162f7565b5b058101905068056bc75e2d6310000083830281614807576148066162f7565b5b0591506005828161481b5761481a6162f7565b5b058101905068056bc75e2d631000008383028161483b5761483a6162f7565b5b0591506007828161484f5761484e6162f7565b5b058101905068056bc75e2d631000008383028161486f5761486e6162f7565b5b05915060098281614883576148826162f7565b5b058101905068056bc75e2d63100000838302816148a3576148a26162f7565b5b059150600b82816148b7576148b66162f7565b5b05810190506002810290506064818601816148d5576148d46162f7565b5b05955050505050505b919050565b6040518061012001604052805f81526020015f81526020015f81526020015f600481111561491457614913615940565b5b81526020015f73ffffffffffffffffffffffffffffffffffffffff1681526020015f73ffffffffffffffffffffffffffffffffffffffff1681526020015f73ffffffffffffffffffffffffffffffffffffffff1681526020015f81526020015f81525090565b60405180604001604052805f81526020015f81525090565b60405180604001604052805f81526020015f81525090565b5f604051905090565b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f8083601f8401126149dc576149db6149bb565b5b8235905067ffffffffffffffff8111156149f9576149f86149bf565b5b602083019150836020820283011115614a1557614a146149c3565b5b9250929050565b5f8060208385031215614a3257614a316149b3565b5b5f83013567ffffffffffffffff811115614a4f57614a4e6149b7565b5b614a5b858286016149c7565b92509250509250929050565b5f81519050919050565b5f82825260208201905092915050565b5f819050602082019050919050565b5f819050919050565b614aa281614a90565b82525050565b5f614ab38383614a99565b60208301905092915050565b5f602082019050919050565b5f614ad582614a67565b614adf8185614a71565b9350614aea83614a81565b805f5b83811015614b1a578151614b018882614aa8565b9750614b0c83614abf565b925050600181019050614aed565b5085935050505092915050565b5f6040820190508181035f830152614b3f8185614acb565b90508181036020830152614b538184614acb565b90509392505050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f614b8582614b5c565b9050919050565b614b9581614b7b565b8114614b9f575f80fd5b50565b5f81359050614bb081614b8c565b92915050565b5f601f19601f8301169050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b614bfc82614bb6565b810181811067ffffffffffffffff82111715614c1b57614c1a614bc6565b5b80604052505050565b5f614c2d6149aa565b9050614c398282614bf3565b919050565b5f67ffffffffffffffff821115614c5857614c57614bc6565b5b602082029050602081019050919050565b5f80fd5b5f80fd5b614c7a81614a90565b8114614c84575f80fd5b50565b5f81359050614c9581614c71565b92915050565b60058110614ca7575f80fd5b50565b5f81359050614cb881614c9b565b92915050565b5f80fd5b5f67ffffffffffffffff821115614cdc57614cdb614bc6565b5b614ce582614bb6565b9050602081019050919050565b828183375f83830152505050565b5f614d12614d0d84614cc2565b614c24565b905082815260208101848484011115614d2e57614d2d614cbe565b5b614d39848285614cf2565b509392505050565b5f82601f830112614d5557614d546149bb565b5b8135614d65848260208601614d00565b91505092915050565b5f6101408284031215614d8457614d83614c69565b5b614d8f610140614c24565b90505f614d9e84828501614c87565b5f830152506020614db184828501614c87565b6020830152506040614dc584828501614c87565b6040830152506060614dd984828501614caa565b6060830152506080614ded84828501614ba2565b60808301525060a0614e0184828501614ba2565b60a08301525060c0614e1584828501614ba2565b60c08301525060e0614e2984828501614c87565b60e083015250610100614e3e84828501614c87565b6101008301525061012082013567ffffffffffffffff811115614e6457614e63614c6d565b5b614e7084828501614d41565b6101208301525092915050565b5f60808284031215614e9257614e91614c69565b5b614e9c6080614c24565b90505f82013567ffffffffffffffff811115614ebb57614eba614c6d565b5b614ec784828501614d6e565b5f83015250602082013567ffffffffffffffff811115614eea57614ee9614c6d565b5b614ef684828501614d41565b6020830152506040614f0a84828501614c87565b6040830152506060614f1e84828501614c87565b60608301525092915050565b5f614f3c614f3784614c3e565b614c24565b90508083825260208201905060208402830185811115614f5f57614f5e6149c3565b5b835b81811015614fa657803567ffffffffffffffff811115614f8457614f836149bb565b5b808601614f918982614e7d565b85526020850194505050602081019050614f61565b5050509392505050565b5f82601f830112614fc457614fc36149bb565b5b8135614fd4848260208601614f2a565b91505092915050565b5f67ffffffffffffffff821115614ff757614ff6614bc6565b5b602082029050602081019050919050565b5f6040828403121561501d5761501c614c69565b5b6150276040614c24565b90505f61503684828501614c87565b5f83015250602061504984828501614c87565b60208301525092915050565b5f61506761506284614fdd565b614c24565b9050808382526020820190506040840283018581111561508a576150896149c3565b5b835b818110156150b3578061509f8882615008565b84526020840193505060408101905061508c565b5050509392505050565b5f82601f8301126150d1576150d06149bb565b5b81356150e1848260208601615055565b91505092915050565b5f6150f482614b7b565b9050919050565b615104816150ea565b811461510e575f80fd5b50565b5f8135905061511f816150fb565b92915050565b5f805f805f60a0868803121561513e5761513d6149b3565b5b5f61514b88828901614ba2565b955050602086013567ffffffffffffffff81111561516c5761516b6149b7565b5b61517888828901614fb0565b945050604086013567ffffffffffffffff811115615199576151986149b7565b5b6151a5888289016150bd565b93505060606151b688828901615111565b92505060806151c788828901614c87565b9150509295509295909350565b6151dd81614b7b565b82525050565b5f6020820190506151f65f8301846151d4565b92915050565b5f60208284031215615211576152106149b3565b5b5f82013567ffffffffffffffff81111561522e5761522d6149b7565b5b61523a84828501614d6e565b91505092915050565b5f819050919050565b61525581615243565b82525050565b5f60208201905061526e5f83018461524c565b92915050565b5f8115159050919050565b61528881615274565b82525050565b5f6020820190506152a15f83018461527f565b92915050565b5f602082840312156152bc576152bb6149b3565b5b5f6152c984828501614ba2565b91505092915050565b6152db81614a90565b82525050565b5f6020820190506152f45f8301846152d2565b92915050565b5f60ff82169050919050565b61530f816152fa565b8114615319575f80fd5b50565b5f8135905061532a81615306565b92915050565b5f60208284031215615345576153446149b3565b5b5f6153528482850161531c565b91505092915050565b5f80fd5b5f61014082840312156153755761537461535b565b5b81905092915050565b5f60208284031215615393576153926149b3565b5b5f82013567ffffffffffffffff8111156153b0576153af6149b7565b5b6153bc8482850161535f565b91505092915050565b5f7fff0000000000000000000000000000000000000000000000000000000000000082169050919050565b6153f9816153c5565b82525050565b5f81519050919050565b5f82825260208201905092915050565b5f5b8381101561543657808201518184015260208101905061541b565b5f8484015250505050565b5f61544b826153ff565b6154558185615409565b9350615465818560208601615419565b61546e81614bb6565b840191505092915050565b5f60e08201905061548c5f83018a6153f0565b818103602083015261549e8189615441565b905081810360408301526154b28188615441565b90506154c160608301876152d2565b6154ce60808301866151d4565b6154db60a083018561524c565b81810360c08301526154ed8184614acb565b905098975050505050505050565b5f7fffffffff0000000000000000000000000000000000000000000000000000000082169050919050565b61552f816154fb565b82525050565b5f6020820190506155485f830184615526565b92915050565b5f8083601f840112615563576155626149bb565b5b8235905067ffffffffffffffff8111156155805761557f6149bf565b5b60208301915083602082028301111561559c5761559b6149c3565b5b9250929050565b5f80602083850312156155b9576155b86149b3565b5b5f83013567ffffffffffffffff8111156155d6576155d56149b7565b5b6155e28582860161554e565b92509250509250929050565b5f8083601f840112615603576156026149bb565b5b8235905067ffffffffffffffff8111156156205761561f6149bf565b5b60208301915083602082028301111561563c5761563b6149c3565b5b9250929050565b5f8060208385031215615659576156586149b3565b5b5f83013567ffffffffffffffff811115615676576156756149b7565b5b615682858286016155ee565b92509250509250929050565b5f81519050919050565b5f82825260208201905092915050565b5f819050602082019050919050565b604082015f8201516156cb5f850182614a99565b5060208201516156de6020850182614a99565b50505050565b5f6156ef83836156b7565b60408301905092915050565b5f602082019050919050565b5f6157118261568e565b61571b8185615698565b9350615726836156a8565b805f5b8381101561575657815161573d88826156e4565b9750615748836156fb565b925050600181019050615729565b5085935050505092915050565b5f6080820190508181035f83015261577b8187615707565b905061578a60208301866151d4565b61579760408301856152d2565b6157a460608301846152d2565b95945050505050565b5f805f606084860312156157c4576157c36149b3565b5b5f6157d186828701614ba2565b93505060206157e286828701614ba2565b92505060406157f386828701614ba2565b9150509250925092565b5f8060408385031215615813576158126149b3565b5b5f61582085828601614ba2565b925050602061583185828601614c87565b9150509250929050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b5f60608201905061587b5f8301866151d4565b61588860208301856151d4565b61589560408301846152d2565b949350505050565b6158a681615274565b81146158b0575f80fd5b50565b5f815190506158c18161589d565b92915050565b5f602082840312156158dc576158db6149b3565b5b5f6158e9848285016158b3565b91505092915050565b5f6040820190506159055f8301856151d4565b61591260208301846152d2565b9392505050565b5f60408201905061592c5f83018561524c565b61593960208301846152d2565b9392505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b6005811061597e5761597d615940565b5b50565b5f81905061598e8261596d565b919050565b5f61599d82615981565b9050919050565b6159ad81615993565b82525050565b6159bc81614b7b565b82525050565b61012082015f8201516159d75f850182614a99565b5060208201516159ea6020850182614a99565b5060408201516159fd6040850182614a99565b506060820151615a1060608501826159a4565b506080820151615a2360808501826159b3565b5060a0820151615a3660a08501826159b3565b5060c0820151615a4960c08501826159b3565b5060e0820151615a5c60e0850182614a99565b50610100820151615a71610100850182614a99565b50505050565b5f61016082019050615a8b5f83018661524c565b615a9860208301856159c2565b615aa661014083018461524c565b949350505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f615ae582614a90565b9150615af083614a90565b9250828201905080821115615b0857615b07615aae565b5b92915050565b5f615b1882614a90565b9150615b2383614a90565b9250828203905081811115615b3b57615b3a615aae565b5b92915050565b5f604082019050615b545f8301856152d2565b615b6160208301846152d2565b9392505050565b5f615b733683614d6e565b9050919050565b5f604082019050615b8d5f8301856151d4565b615b9a602083018461524c565b9392505050565b7f4549503731323a20556e696e697469616c697a656400000000000000000000005f82015250565b5f615bd5601583615409565b9150615be082615ba1565b602082019050919050565b5f6020820190508181035f830152615c0281615bc9565b9050919050565b5f80fd5b5f8235600161014003833603038112615c2957615c28615c09565b5b80830191505092915050565b5f82356001608003833603038112615c5057615c4f615c09565b5b80830191505092915050565b5f60208284031215615c7157615c706149b3565b5b5f615c7e84828501614caa565b91505092915050565b5f615c9182614a90565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203615cc357615cc2615aae565b5b600182019050919050565b5f615cd93683614e7d565b9050919050565b5f819050919050565b5f67ffffffffffffffff82169050919050565b5f819050919050565b5f615d1f615d1a615d1584615ce0565b615cfc565b615ce9565b9050919050565b615d2f81615d05565b82525050565b5f602082019050615d485f830184615d26565b92915050565b5f81519050615d5c81614b8c565b92915050565b5f60208284031215615d7757615d766149b3565b5b5f615d8484828501615d4e565b91505092915050565b5f615d9782614b5c565b9050919050565b615da781615d8d565b8114615db1575f80fd5b50565b5f81519050615dc281615d9e565b92915050565b5f81519050615dd681614c71565b92915050565b5f81519050615dea81615306565b92915050565b615df981615243565b8114615e03575f80fd5b50565b5f81519050615e1481615df0565b92915050565b5f805f805f805f60e0888a031215615e3557615e346149b3565b5b5f615e428a828b01615db4565b9750506020615e538a828b01615db4565b9650506040615e648a828b01615dc8565b9550506060615e758a828b01615dc8565b9450506080615e868a828b01615ddc565b93505060a0615e978a828b01615e06565b92505060c0615ea88a828b01615e06565b91505092959891949750929550565b615ec0816152fa565b82525050565b5f60e082019050615ed95f83018a6151d4565b615ee660208301896151d4565b615ef360408301886152d2565b615f0060608301876152d2565b615f0d6080830186615eb7565b615f1a60a083018561524c565b615f2760c083018461524c565b98975050505050505050565b5f80fd5b5f80fd5b5f8085851115615f4e57615f4d615f33565b5b83861115615f5f57615f5e615f37565b5b6001850283019150848603905094509492505050565b5f82905092915050565b5f82821b905092915050565b5f615f968383615f75565b82615fa181356154fb565b92506004821015615fe157615fdc7fffffffff0000000000000000000000000000000000000000000000000000000083600403600802615f7f565b831692505b505092915050565b5f82825260208201905092915050565b5f6160048385615fe9565b9350616011838584614cf2565b61601a83614bb6565b840190509392505050565b5f6040820190506160385f8301866151d4565b818103602083015261604b818486615ff9565b9050949350505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f600282049050600182168061609957607f821691505b6020821081036160ac576160ab616055565b5b50919050565b5f602082840312156160c7576160c66149b3565b5b5f6160d484828501615dc8565b91505092915050565b5f819050919050565b5f6161006160fb6160f6846160dd565b615cfc565b6152fa565b9050919050565b616110816160e6565b82525050565b5f6040820190506161295f830185616107565b61613660208301846152d2565b9392505050565b5f8160011c9050919050565b5f808291508390505b60018511156161925780860481111561616e5761616d615aae565b5b600185161561617d5780820291505b808102905061618b8561613d565b9450616152565b94509492505050565b5f826161aa5760019050616265565b816161b7575f9050616265565b81600181146161cd57600281146161d757616206565b6001915050616265565b60ff8411156161e9576161e8615aae565b5b8360020a915084821115616200576161ff615aae565b5b50616265565b5060208310610133831016604e8410600b841016171561623b5782820a90508381111561623657616235615aae565b5b616265565b6162488484846001616149565b9250905081840481111561625f5761625e615aae565b5b81810290505b9392505050565b5f61627682614a90565b915061628183614a90565b92506162ae7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff848461619b565b905092915050565b5f6162c082614a90565b91506162cb83614a90565b92508282026162d981614a90565b915082820484148315176162f0576162ef615aae565b5b5092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601260045260245ffd5b5f61632e82614a90565b915061633983614a90565b925082616349576163486162f7565b5b828204905092915050565b5f6060820190506163675f8301866151d4565b61637460208301856151d4565b6163816040830184615526565b949350505050565b5f81519050919050565b5f61639d82616389565b6163a78185615fe9565b93506163b7818560208601615419565b6163c081614bb6565b840191505092915050565b5f6040820190506163de5f83018561524c565b81810360208301526163f08184616393565b90509392505050565b5f81905092915050565b5f61640d82616389565b61641781856163f9565b9350616427818560208601615419565b80840191505092915050565b5f61643e8284616403565b915081905092915050565b5f6020828403121561645e5761645d6149b3565b5b5f61646b84828501615e06565b91505092915050565b5f819050919050565b5f61648782616474565b915061649283616474565b9250826164a2576164a16162f7565b5b60015f0383147f8000000000000000000000000000000000000000000000000000000000000000831416156164da576164d9615aae565b5b828205905092915050565b5f6164ef82616474565b91506164fa83616474565b92508282019050828112155f8312168382125f8412151617156165205761651f615aae565b5b92915050565b5f61653082616474565b915061653b83616474565b925082820261654981616474565b91507f800000000000000000000000000000000000000000000000000000000000000084145f841216156165805761657f615aae565b5b828205841483151761659557616594615aae565b5b5092915050565b5f819050815f5260205f209050919050565b5f6020601f8301049050919050565b5f600883026165ec7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82615f7f565b6165f68683615f7f565b95508019841693508086168417925050509392505050565b5f61662861662361661e84614a90565b615cfc565b614a90565b9050919050565b5f819050919050565b6166418361660e565b61665561664d8261662f565b8484546165bd565b825550505050565b5f90565b61666961665d565b616674818484616638565b505050565b5b818110156166975761668c5f82616661565b60018101905061667a565b5050565b601f8211156166dc576166ad8161659c565b6166b6846165ae565b810160208510156166c5578190505b6166d96166d1856165ae565b830182616679565b50505b505050565b5f82821c905092915050565b5f6166fc5f19846008026166e1565b1980831691505092915050565b5f61671483836166ed565b9150826002028217905092915050565b61672d826153ff565b67ffffffffffffffff81111561674657616745614bc6565b5b6167508254616082565b61675b82828561669b565b5f60209050601f83116001811461678c575f841561677a578287015190505b6167848582616709565b8655506167eb565b601f19841661679a8661659c565b5f5b828110156167c15784890151825560018201915060208501945060208101905061679c565b868310156167de57848901516167da601f8916826166ed565b8355505b6001600288020188555050505b505050505050565b5f60a0820190506168065f83018861524c565b616813602083018761524c565b616820604083018661524c565b61682d60608301856152d2565b61683a60808301846151d4565b9695505050505050565b7f6f7574206f6620626f756e6473000000000000000000000000000000000000005f82015250565b5f616878600d83615409565b915061688382616844565b602082019050919050565b5f6020820190508181035f8301526168a58161686c565b9050919050565b7f496e76616c6964206578706f6e656e74000000000000000000000000000000005f82015250565b5f6168e0601083615409565b91506168eb826168ac565b602082019050919050565b5f6020820190508181035f83015261690d816168d4565b9050919050565b7f78206f7574206f6620626f756e647300000000000000000000000000000000005f82015250565b5f616948600f83615409565b915061695382616914565b602082019050919050565b5f6020820190508181035f8301526169758161693c565b9050919050565b7f79206f7574206f6620626f756e647300000000000000000000000000000000005f82015250565b5f6169b0600f83615409565b91506169bb8261697c565b602082019050919050565b5f6020820190508181035f8301526169dd816169a4565b9050919050565b7f70726f64756374206f7574206f6620626f756e647300000000000000000000005f82015250565b5f616a18601583615409565b9150616a23826169e4565b602082019050919050565b5f6020820190508181035f830152616a4581616a0c565b9050919050565b5f608082019050616a5f5f83018761524c565b616a6c6020830186615eb7565b616a79604083018561524c565b616a86606083018461524c565b9594505050505056fea2646970667358221220f015e1bff79b818a06cae08a4757548a7c3d4b969235a1163efb8715e6be426964736f6c63430008180033",
-      "sourceMap":"1530:19259:131:-:0;;;2813:132;;;;;;;;;;2837:22;:20;;;:22;;:::i;:::-;1530:19259;;7709:422:58;7824:30;7857:26;:24;;;:26;;:::i;:::-;7824:59;;7898:1;:15;;;;;;;;;;;;7894:76;;;7936:23;;;;;;;;;;;;;;7894:76;8001:16;7983:34;;:1;:14;;;;;;;;;;;;:34;;;7979:146;;8050:16;8033:1;:14;;;:33;;;;;;;;;;;;;;;;;;8085:29;8097:16;8085:29;;;;;;:::i;:::-;;;;;;;;7979:146;7758:373;7709:422::o;9071:205::-;9129:30;9171:12;9186:27;:25;;;:27;;:::i;:::-;9171:42;;9256:4;9246:14;;9232:38;9071:205;:::o;8819:122::-;8887:7;3147:66;8913:21;;8906:28;;8819:122;:::o;7:101:140:-;43:7;83:18;76:5;72:30;61:41;;7:101;;;:::o;114:115::-;199:23;216:5;199:23;:::i;:::-;194:3;187:36;114:115;;:::o;235:218::-;326:4;364:2;353:9;349:18;341:26;;377:69;443:1;432:9;428:17;419:6;377:69;:::i;:::-;235:218;;;;:::o;1530:19259:131:-;;;;;;;",
-      "linkReferences":{
-         
+    },
+    "settings": {
+      "remappings": [
+        "@openzeppelin-contracts-5.4.0-rc.1/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/",
+        "@openzeppelin-contracts-upgradeable-5.4.0-rc.1/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/",
+        "config/=dependencies/spectra-contracts-configs-main/script/",
+        "core-v2-staging/=dependencies/core-v2-staging/src/",
+        "core-v2/=dependencies/core-v2-staging/",
+        "diamond-router-V1/=dependencies/core-v2-staging/dependencies/diamond-router-V1/src/",
+        "ds-test/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/forge-std/lib/ds-test/src/",
+        "erc4626-tests/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/openzeppelin-contracts-upgradeable/lib/erc4626-tests/",
+        "forge-std-1.9.7/=dependencies/forge-std-1.9.7/src/",
+        "forge-std/=dependencies/forge-std-1.9.7/src/",
+        "halmos-cheatcodes/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/openzeppelin-contracts-upgradeable/lib/halmos-cheatcodes/src/",
+        "openzeppelin-contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/",
+        "openzeppelin-contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/",
+        "openzeppelin-erc20-basic/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/token/ERC20/",
+        "openzeppelin-math/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/utils/math/",
+        "roles/=dependencies/spectra-contracts-configs-main/access/",
+        "solidity-stringutils/=dependencies/core-v2-staging/dependencies/diamond-router-V1/lib/solidity-stringutils/",
+        "spectra-contracts-configs-main/=dependencies/spectra-contracts-configs-main/src/",
+        "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/:@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/",
+        "dependencies/core-v2-staging:script/=dependencies/core-v2-staging/script/",
+        "dependencies/core-v2-staging:src/=dependencies/core-v2-staging/src/"
+      ],
+      "optimizer": {
+        "enabled": true,
+        "runs": 200
+      },
+      "metadata": {
+        "bytecodeHash": "ipfs"
+      },
+      "compilationTarget": {
+        "src/LimitOrderEngine.sol": "LimitOrderEngine"
+      },
+      "evmVersion": "prague",
+      "libraries": {}
+    },
+    "sources": {
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/AuthorityUtils.sol": {
+        "keccak256": "0x05fd06ae5bca9dc7470fb2dfae764315c81a84f591e86be6fec0c115474edc6c",
+        "urls": [
+          "bzz-raw://998ffed150fad3264d73c847f2ca35ee750d747ece382bb48885e8c8dce62941",
+          "dweb:/ipfs/QmSjacwVExF2T9ZFysQQ3vVLJbDQ16G7zd81SDxPCfNFxe"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAccessManaged.sol": {
+        "keccak256": "0x4ad12e231e8b1567e4086b134f5ff59a08cb8b1ea6d8fa9ecceec30b4b28ad89",
+        "urls": [
+          "bzz-raw://81657c0f105f4c92c1a67bcbc7a6afb6c2a937616b8168a63f3fdff61ea4957f",
+          "dweb:/ipfs/QmS3ZBTCr34uuVCXVRfuuvh5QRT9upruNhi222EjJ7tgJp"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAccessManager.sol": {
+        "keccak256": "0x3a129298f50d5e1e8d46d91eb6aa40e18183b76f6983e13a0a1e5f43a8faedb6",
+        "urls": [
+          "bzz-raw://e1a20642c110215a14f97d7cbd7048a19db9b9500b020b17b96138406ab6ab07",
+          "dweb:/ipfs/QmRbrcJjQzGnz7T6KYCpZYtDYpx6id2KSDis7DPQhye1Zr"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAuthority.sol": {
+        "keccak256": "0xd7b800fcca190ec8030b5d5792d7b5e6de3213ab322ada322e905540c58edd3b",
+        "urls": [
+          "bzz-raw://b0d5da4f1aa7120b6fac945df72ff3661b0d1ee9bc175023ec29cecc6324c76b",
+          "dweb:/ipfs/QmPDSsk9WcVwx4Je1t59txPUzh7si4Hnhu11VPjrTwQFPL"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1271.sol": {
+        "keccak256": "0x67ddf13274cfd1dd994552801d8e2f67a32e2301d6680d7bb2eda99a7feff5eb",
+        "urls": [
+          "bzz-raw://137e025f914ff2d56889b68629337b5f4dc4cba181cd0a3ec42a2e0cdf1d396a",
+          "dweb:/ipfs/QmaVBNddWRuukyYZKAKDsvDZ64JWGCiMmF95cktsfH9muM"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1363.sol": {
+        "keccak256": "0xcef3dfbf36b24b3d0bd209f8e1869f4c86287878240f66e651b122d26448fcc3",
+        "urls": [
+          "bzz-raw://ebc799e73eaf8a32c7be984f422f5b237e4b36277251968c60f74b282ecd1c91",
+          "dweb:/ipfs/QmczzYkjSv93ZtPswneWbYSjkd4LEbhkg8iB4ZATvCEfCz"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC165.sol": {
+        "keccak256": "0x71f27f20e8998b0d0266a5b5a9a73346baf513c98f7fe941d13f293c6f5f30fa",
+        "urls": [
+          "bzz-raw://8a810b05b2727a18024c91842beb4a65c6785d477c931a0e679fedba4963f73c",
+          "dweb:/ipfs/QmdWk9H4YuKU9M86VsZD1syn4SMbVJCvoRGRwn74gLPRLG"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC20.sol": {
+        "keccak256": "0x742c788bf2723742350a299027925399eb5b1da6b4971af846aabe742f7ce9fa",
+        "urls": [
+          "bzz-raw://3a001c31d79f8df22a8b8111c728ab6719c516391e7687a16648c84242c3641b",
+          "dweb:/ipfs/QmT7uM2J8pPKUjJJzVNYQiswd4eG6AU1CWDecCWdHrm3oz"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC20Metadata.sol": {
+        "keccak256": "0x877f2cab8e4dfa6174d0177f04181319da118a7e367493ad7c68ee4cb8be7205",
+        "urls": [
+          "bzz-raw://c368c7a1eec4c3a6ae815e775f9bdbdd0130ad0c0b09447e9b9d56a2a4cafe2f",
+          "dweb:/ipfs/QmbbMtEf5ZY6ZpQKLsVvmsHLB7A639qnEiAqhjSP3k17tY"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC3156FlashBorrower.sol": {
+        "keccak256": "0xd470da87c982da3f6be8555b63f10d66462054def9d7da20aae37c3ee3c96d58",
+        "urls": [
+          "bzz-raw://c76692163f771760363ff3001755a6e1331c0b25b23ddaf5e072c0ed67f4b5cc",
+          "dweb:/ipfs/QmXhYb6dwmoGq1ZcGfbuC5RaYFaDLG3FdqhHC4GqNe75DP"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC3156FlashLender.sol": {
+        "keccak256": "0xbf67f5abbdb40a69d887f34bb9c578945c4d80ea5566264a16165bf49d06665b",
+        "urls": [
+          "bzz-raw://6e325477bf279e74e4c4d13d5014a60697f35d20134ce424970f2336a7740423",
+          "dweb:/ipfs/QmVrthF7KY6kp2RXrfiCZk9uZwPYHdPCqgiPpDeShJWu3z"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC4626.sol": {
+        "keccak256": "0x085fcdfdf42d0092040e702303f54f9a0a3540bf25921588f0c44f2a870485df",
+        "urls": [
+          "bzz-raw://cb8e63b28c91aaa8c5c6e393c39d53ced9868128ce60f8a0d38d57f7eebfa59f",
+          "dweb:/ipfs/QmNfU4XSGnv8eD5UREt7Rs5TiLT2iVGd2CWpka3brngmRT"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC5267.sol": {
+        "keccak256": "0x473d635a93adf200d4ec9ef1cb3ba9d33230d546fa0eb8ab95e6ed5a461da5d9",
+        "urls": [
+          "bzz-raw://28dd2f7722f144efa18ad2797c744d214e02495f948d4d73b354ef049a6f813f",
+          "dweb:/ipfs/QmeSyAoJk1FuS6F7MzJj6dvnqd6jNz6pNP2WjjLPhDLHdg"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC7913.sol": {
+        "keccak256": "0xfa287c745741ef58af71e1068ebf9771fe55bc17c9efe39517d942a005744f24",
+        "urls": [
+          "bzz-raw://78a7f7ab52e2ea38fb0f79ad786bb575af5e6a60a44a31bef37fbdeffd88330f",
+          "dweb:/ipfs/QmZSiVgsapHHmQspCYDVGjayZANcvct4m2i65QdC2N3VGU"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/IERC20.sol": {
+        "keccak256": "0xaa5c002dccc71cf9d6dd92a9fa87f205f32b0b9204303c442d567bfcb832d69d",
+        "urls": [
+          "bzz-raw://f17355804cadb61737c6d7ebf9539cd27eacd8a9099ffe711ce9dc0a2dd07442",
+          "dweb:/ipfs/QmSVBcaVaaC9SxVsYsmfY1U3du3inqbNGPEpcMY4KkRrrj"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/extensions/IERC20Metadata.sol": {
+        "keccak256": "0x090e3e7ffd747b5546cb7033e5425ec7fc8813da81f8bee455318fd8af5cc3a0",
+        "urls": [
+          "bzz-raw://423facd62c0103f6810c7b43c1cf3002e8728a9e3aa57c32c46d100137a6f2ae",
+          "dweb:/ipfs/QmPcMF3srsURFQRpQNCC5ALv8eGVFeupK8TYirBNTWVC8b"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/utils/SafeERC20.sol": {
+        "keccak256": "0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5",
+        "urls": [
+          "bzz-raw://8150ceb4ac947e8a442b2a9c017e01e880b2be2dd958f1fa9bc405f4c5a86508",
+          "dweb:/ipfs/QmbcBmFX66AY6Kbhnd5gx7zpkgqnUafo43XnmayAM7zVdB"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Bytes.sol": {
+        "keccak256": "0xee79e30c45319d56e7536317e1776686ec2d475795a27c3f2ac7e9c2f4edef7f",
+        "urls": [
+          "bzz-raw://d0952f3c09421d8b2b3896b4789ad655a114b9206365b5363c1dd0a75583997d",
+          "dweb:/ipfs/QmQPemDMHjWhhLmazue7gHnZRYxcbz9nbz4pKcC7ioSFyz"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Panic.sol": {
+        "keccak256": "0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a",
+        "urls": [
+          "bzz-raw://c6a5ff4f9fd8649b7ee20800b7fa387d3465bd77cf20c2d1068cd5c98e1ed57a",
+          "dweb:/ipfs/QmVSaVJf9FXFhdYEYeCEfjMVHrxDh5qL4CGkxdMWpQCrqG"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Strings.sol": {
+        "keccak256": "0x72d89c30d5c7c7f7923677b3738ceffe5a5671f885b4637badd0084c3f438213",
+        "urls": [
+          "bzz-raw://15ad622659ea59783478bc73db26d57a74f400aef716a6478613919e45bd4b71",
+          "dweb:/ipfs/QmPcaMREGhoehgMhY9s6BUrsVoK7F6YNU1xkG4VFe5yXjT"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/ECDSA.sol": {
+        "keccak256": "0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84",
+        "urls": [
+          "bzz-raw://8e25e4bdb7ae1f21d23bfee996e22736fc0ab44cfabedac82a757b1edc5623b9",
+          "dweb:/ipfs/QmQdWQvB6JCP9ZMbzi8EvQ1PTETqkcTWrbcVurS7DKpa5n"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/MessageHashUtils.sol": {
+        "keccak256": "0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631",
+        "urls": [
+          "bzz-raw://b16d45febff462bafd8a5669f904796a835baf607df58a8461916d3bf4f08c59",
+          "dweb:/ipfs/QmU2eJFpjmT4vxeJWJyLeQb8Xht1kdB8Y6MKLDPFA9WPux"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/SignatureChecker.sol": {
+        "keccak256": "0x60da29c52e83ab33d9335cd153b7ef333d1758731eb5a600d13228a5ea30a704",
+        "urls": [
+          "bzz-raw://f9d21b7b68fc9b5406d8e762aaef2d4f3d06de774b37486555404919394a6b35",
+          "dweb:/ipfs/QmQZYwwhyZyYfmcKKeLm6g7CBb8tF42XUVXE9mvywLnUJQ"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/introspection/IERC165.sol": {
+        "keccak256": "0x2820b23a27421cbb9be0239e2210efbcdb73c3224e1a48acb7daff8d7d26964f",
+        "urls": [
+          "bzz-raw://a00d4c01544a03232adb233c3e82d1b1eb82bde78df17f05fd56232f2773bd23",
+          "dweb:/ipfs/QmZ9tPFfYYMdc3PCJPcAWCdvJ3Gt646MJxk2RZ3D9tjeZN"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/Math.sol": {
+        "keccak256": "0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6",
+        "urls": [
+          "bzz-raw://6c5fab4970634f9ab9a620983dc1c8a30153981a0b1a521666e269d0a11399d3",
+          "dweb:/ipfs/QmVRnBC575MESGkEHndjujtR7qub2FzU9RWy9eKLp4hPZB"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/SafeCast.sol": {
+        "keccak256": "0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54",
+        "urls": [
+          "bzz-raw://b1d578337048cad08c1c03041cca5978eff5428aa130c781b271ad9e5566e1f8",
+          "dweb:/ipfs/QmPFKL2r9CBsMwmUqqdcFPfHZB2qcs9g1HDrPxzWSxomvy"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/SignedMath.sol": {
+        "keccak256": "0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3",
+        "urls": [
+          "bzz-raw://db5fbb3dddd8b7047465b62575d96231ba8a2774d37fb4737fbf23340fabbb03",
+          "dweb:/ipfs/QmVUSvooZKEdEdap619tcJjTLcAuH6QBdZqAzWwnAXZAWJ"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/access/manager/AccessManagedUpgradeable.sol": {
+        "keccak256": "0xafc6430a5a632a57bf0e1596dccdad8f208f449cfc340878dc1789e5f5b570d5",
+        "urls": [
+          "bzz-raw://1935bb38eac62a468fdc3f00174e4cb28b476668895ddfea5e0bcf56297b8145",
+          "dweb:/ipfs/QmVmSMB2tykT9t5ZoMkREn2zNzYtK2ufNdxRYo3B7MLvVT"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/proxy/utils/Initializable.sol": {
+        "keccak256": "0xdb4d24ee2c087c391d587cd17adfe5b3f9d93b3110b1388c2ab6c7c0ad1dcd05",
+        "urls": [
+          "bzz-raw://ab7b6d5b9e2b88176312967fe0f0e78f3d9a1422fa5e4b64e2440c35869b5d08",
+          "dweb:/ipfs/QmXKYWWyzcLg1B2k7Sb1qkEXgLCYfXecR9wYW5obRzWP1Q"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/ContextUpgradeable.sol": {
+        "keccak256": "0xdbef5f0c787055227243a7318ef74c8a5a1108ca3a07f2b3a00ef67769e1e397",
+        "urls": [
+          "bzz-raw://08e39f23d5b4692f9a40803e53a8156b72b4c1f9902a88cd65ba964db103dab9",
+          "dweb:/ipfs/QmPKn6EYDgpga7KtpkA8wV2yJCYGMtc9K4LkJfhKX2RVSV"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/PausableUpgradeable.sol": {
+        "keccak256": "0xa6bf6b7efe0e6625a9dcd30c5ddf52c4c24fe8372f37c7de9dbf5034746768d5",
+        "urls": [
+          "bzz-raw://8c353ee3705bbf6fadb84c0fb10ef1b736e8ca3ca1867814349d1487ed207beb",
+          "dweb:/ipfs/QmcugaPssrzGGE8q4YZKm2ZhnD3kCijjcgdWWg76nWt3FY"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/ReentrancyGuardUpgradeable.sol": {
+        "keccak256": "0x361126a17677994081cd9cb69c3f50cffff6e920d25cb7e428acdb1ae41d1866",
+        "urls": [
+          "bzz-raw://19ae787a7dd001269cd60a394b1a5261b78925a0fc3a6f927beb2986a9aa56cf",
+          "dweb:/ipfs/QmYLfXiuKmcRgTDBEDXMMjXU8t6JxsspUmjxYzqWS55oEv"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/cryptography/EIP712Upgradeable.sol": {
+        "keccak256": "0xba34a957324b4b1cb867111b948afc0cda72f5e9fdc7cb9b9b7bfeb0c2ad4edb",
+        "urls": [
+          "bzz-raw://214590a0ca86c1209ef46f240c06ea1b9eb64e55bc98c2e3efc470fb682002f0",
+          "dweb:/ipfs/Qme7wm5XTn8U3Xmn35DtpXw817888Drjm9YhJP2vQAunqV"
+        ],
+        "license": "MIT"
+      },
+      "dependencies/core-v2-staging/src/interfaces/IPrincipalToken.sol": {
+        "keccak256": "0xcb0a909e32a422ae2d9fb36f8664555d82cc6d602cd9584a8f2a577a834122f4",
+        "urls": [
+          "bzz-raw://c85ec7286448237ad3a0214983d92f64f2c4640caf484a72914fc794441df1d8",
+          "dweb:/ipfs/QmY5dGHStJVRmTkErDLrAW53akHQYZ4iSebJDXahFP2jyE"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "dependencies/core-v2-staging/src/interfaces/IRegistry.sol": {
+        "keccak256": "0x773e8224f8d8d7f5cfe89904c653ea1f1594506f0826b1735c6ed8553c517ebc",
+        "urls": [
+          "bzz-raw://2beb9308d709f19135019ab138f8352561657c09f403354f2a86a5432f4f8ed6",
+          "dweb:/ipfs/Qmb9fnNuDSLF5iURLeKCaLAWHWDuLpe2e6XMWCZBkd4d2Y"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "dependencies/core-v2-staging/src/libraries/LogExpMath.sol": {
+        "keccak256": "0x83fa012405dacb88992aa6653d8cf1fe6a00def6abd09e715c79f7a5a5a8fe74",
+        "urls": [
+          "bzz-raw://355bc2a9afcc3a44a90223ab6f42cbdf71722d7ab145ce429c5406052530fba5",
+          "dweb:/ipfs/QmUSPm8tkEJ275eLQ7MP9AWcxs1BMtyreeZyFGK1eD9GEL"
+        ],
+        "license": "GPL-3.0-or-later"
+      },
+      "dependencies/core-v2-staging/src/libraries/RayMath.sol": {
+        "keccak256": "0xeb628b5cf03604856852b140401593daefc51cde6b426f2bccb7b21a4a6f3bff",
+        "urls": [
+          "bzz-raw://0d0eb1f485646176a868b379fd445c06ce97d9ed78809660428484dbca8f943e",
+          "dweb:/ipfs/QmWHgYkWbwRACsfhriTwRv3sp1BZ28UobXSHWfQ62WouY7"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "src/LimitOrderEngine.sol": {
+        "keccak256": "0xc74942259199aff0cc54624b90a1eb48004b3a3650dc3552be2e49350204f5b0",
+        "urls": [
+          "bzz-raw://d59253db9eb3cd08941946dee5b9f02823ab3c2b2bc0ccf5304123d0e01ab1cf",
+          "dweb:/ipfs/QmaNJzuhk4N3Nqqu9YuhfaA7yAY5pPFBgk5Z9ju3CacaP8"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "src/NonceManager.sol": {
+        "keccak256": "0x8bb26a9a69b686e2ee05da2ff9e6e89507755098faa08f927a4398d150ff4dd3",
+        "urls": [
+          "bzz-raw://f98091760d245ebe3198dcd407a26e50bb3f450b16ac65acd157a88204c1804d",
+          "dweb:/ipfs/QmTDD44RtnjdGvS2KxNgsvdtjm6yxUG5o4fUc4s5C7ZXga"
+        ],
+        "license": "MIT"
+      },
+      "src/interfaces/ILimitOrderEngine.sol": {
+        "keccak256": "0x8441b2179f9abf02d9be2132f772ae3ef60667c9e5b57f928eed3040f376f948",
+        "urls": [
+          "bzz-raw://85322926f9db326269ab22e5c6605ac9e908e233c8a909c3a607d93460a20271",
+          "dweb:/ipfs/QmPGWwWScTmakrBs3L6wxcBRo9o7TYNxSWKnyrhExF8wxN"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "src/interfaces/INonce.sol": {
+        "keccak256": "0x6f5e9a88242928d51e57f9c431efd1505b8e68dfeb6e91b4828ddd7a4e0c6395",
+        "urls": [
+          "bzz-raw://1422126a0c945b06c91c25e4fd9d2335dca877e0e21b223b2aa3bd5a39176f24",
+          "dweb:/ipfs/QmZ95i57YmQUcdNxTkRdcWPB7x6XCZEanNemLBMfc3gkjK"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "src/libraries/LimitOrderPricingLibrary.sol": {
+        "keccak256": "0xd43e1f38dd029e0a679aec7a9bde5f9ad30e73530197ffe4796504f28345f9d1",
+        "urls": [
+          "bzz-raw://41fb0bf1ba630a79b4c28ede794f397df5a609ef3952d06083df66336dce894d",
+          "dweb:/ipfs/QmakeKmTA1FjUfq25SU7jCicNExqCEK14MRk2kwX9jkyEZ"
+        ],
+        "license": "BUSL-1.1"
+      },
+      "src/libraries/PricingLibrary.sol": {
+        "keccak256": "0x16fa09df7a72b06ef4d2bdfac079c334c8ea77ae6d248ba695e3903d10de8ac9",
+        "urls": [
+          "bzz-raw://ddfbae13dbedd763e4bfa8f087c9f8c1b383ce8cb1c22ec645337a14f1374d4e",
+          "dweb:/ipfs/QmYBrnfeHjMKqRM9aeJDteGv1mzkbiEUMANTykvi3kxNR2"
+        ],
+        "license": "BUSL-1.1"
       }
-   },
-   "deployedBytecode":{
-      "object":"0x608060405234801561000f575f80fd5b506004361061014b575f3560e01c80638456cb59116100c1578063c0c53b8b1161007a578063c0c53b8b14610380578063c0d786551461039c578063c53a0292146103b8578063cf6fc6e3146103c2578063e74b981b146103f2578063f887ea401461040e5761014b565b80638456cb59146102c757806384b0196e146102d15780638fb36037146102f5578063ada0844914610313578063bd8f11781461032f578063bf7e214f146103625761014b565b80635bd5f77d116101135780635bd5f77d146101f55780635c975abb1461022557806370ae92d21461024357806372c244a8146102735780637a9e5e4b1461028f5780637db458e5146102ab5761014b565b80630c0b8c9c1461014f57806319f752f61461018057806335ee3ffc1461019c5780633f4ba83a146101cd57806346904840146101d7575b5f80fd5b61016960048036038101906101649190614a1c565b61042c565b604051610177929190614b27565b60405180910390f35b61019a60048036038101906101959190615125565b610511565b005b6101b660048036038101906101b19190614a1c565b610853565b6040516101c4929190614b27565b60405180910390f35b6101d5610a4e565b005b6101df610a70565b6040516101ec91906151e3565b60405180910390f35b61020f600480360381019061020a91906151fc565b610a95565b60405161021c919061525b565b60405180910390f35b61022d610b08565b60405161023a919061528e565b60405180910390f35b61025d600480360381019061025891906152a7565b610b2a565b60405161026a91906152e1565b60405180910390f35b61028d60048036038101906102889190615330565b610b3e565b005b6102a960048036038101906102a491906152a7565b610c2f565b005b6102c560048036038101906102c0919061537e565b610d19565b005b6102cf610ec3565b005b6102d9610ee5565b6040516102ec9796959493929190615479565b60405180910390f35b6102fd610fee565b60405161030a9190615535565b60405180910390f35b61032d600480360381019061032891906155a3565b611027565b005b61034960048036038101906103449190615643565b611071565b6040516103599493929190615763565b60405180910390f35b61036a611746565b60405161037791906151e3565b60405180910390f35b61039a600480360381019061039591906157ad565b61177b565b005b6103b660048036038101906103b191906152a7565b6119f2565b005b6103c0611a90565b005b6103dc60048036038101906103d791906157fd565b611a9c565b6040516103e9919061528e565b60405180910390f35b61040c600480360381019061040791906152a7565b611ae4565b005b610416611b82565b60405161042391906151e3565b60405180910390f35b6060806104398484610853565b80925081935050505f5b8251811015610509575f6fffffffffffffffffffffffffffffffff168382815181106104725761047161583b565b5b6020026020010151036104d5578484828181106104925761049161583b565b5b905060200201356040517f84a19ff70000000000000000000000000000000000000000000000000000000081526004016104cc919061525b565b60405180910390fd5b60018382815181106104ea576104e961583b565b5b6020026020010181815103915081815250508080600101915050610443565b509250929050565b60655f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614610597576040517f9165520100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f5b83518110156107ae575f8482815181106105b6576105b561583b565b5b60200260200101516020015103156107a3575f8582815181106105dc576105db61583b565b5b60200260200101515f015190505f6105f382611ba7565b905061060481836101200151611ddc565b8073ffffffffffffffffffffffffffffffffffffffff166323b872dd8360a001518a8987815181106106395761063861583b565b5b6020026020010151602001516040518463ffffffff1660e01b815260040161066393929190615868565b6020604051808303815f875af115801561067f573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906106a391906158c7565b508473ffffffffffffffffffffffffffffffffffffffff1663a9059cbb8360c001518886815181106106d8576106d761583b565b5b60200260200101515f01516040518363ffffffff1660e01b81526004016107009291906158f2565b6020604051808303815f875af115801561071c573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061074091906158c7565b507ffec331350fce78ba658e082a71da20ac9f8d798a99b3c79681c8440cbfe77e0761076b83610a95565b87858151811061077e5761077d61583b565b5b602002602001015160200151604051610798929190615919565b60405180910390a150505b806001019050610599565b508173ffffffffffffffffffffffffffffffffffffffff1663a9059cbb60665f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff16836040518363ffffffff1660e01b815260040161080b9291906158f2565b6020604051808303815f875af1158015610827573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061084b91906158c7565b505050505050565b6060805f8484905090508067ffffffffffffffff81111561087757610876614bc6565b5b6040519080825280602002602001820160405280156108a55781602001602082028036833780820191505090505b5092508067ffffffffffffffff8111156108c2576108c1614bc6565b5b6040519080825280602002602001820160405280156108f05781602001602082028036833780820191505090505b5091505f5b81811015610a45575f60675f8888858181106109145761091361583b565b5b9050602002013581526020019081526020015f206040518060400160405290815f82015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff1681526020015f820160109054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff16815250509050805f01518160200151816fffffffffffffffffffffffffffffffff169150806fffffffffffffffffffffffffffffffff169050868481518110610a0c57610a0b61583b565b5b60200260200101868581518110610a2657610a2561583b565b5b60200260200101828152508281525050505080806001019150506108f5565b50509250929050565b610a66610a59611e8c565b610a61611e93565b611e9f565b610a6e611fe6565b565b60665f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b5f610a9e6148e3565b829050610b007ff34603235044803a1065918322e607156b2ad4b7321677ede0e35900101dccf08285610120015180519060200120604051602001610ae593929190615a77565b60405160208183030381529060405280519060200120612054565b915050919050565b5f80610b1261206d565b9050805f015f9054906101000a900460ff1691505090565b5f602052805f5260405f205f915090505481565b5f8160ff165f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f2054610b8a9190615adb565b9050805f803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f20819055503373ffffffffffffffffffffffffffffffffffffffff167fdc0537f71d06d3708f52baf4ddf6918b25f1a145ba08873de27485682b35cac18360ff1683610c149190615b0e565b83604051610c23929190615b41565b60405180910390a25050565b5f610c38611e8c565b9050610c42611746565b73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff1614610cb157806040517f068ca9d8000000000000000000000000000000000000000000000000000000008152600401610ca891906151e3565b60405180910390fd5b5f8273ffffffffffffffffffffffffffffffffffffffff163b03610d0c57816040517fc2f31e5e000000000000000000000000000000000000000000000000000000008152600401610d0391906151e3565b60405180910390fd5b610d1582612094565b5050565b3373ffffffffffffffffffffffffffffffffffffffff168160a0016020810190610d4391906152a7565b73ffffffffffffffffffffffffffffffffffffffff1614610d90576040517fb331e42100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f610da382610d9e90615b68565b610a95565b905060016fffffffffffffffffffffffffffffffff1660675f8381526020019081526020015f205f015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff1603610e3c57806040517fcee81443000000000000000000000000000000000000000000000000000000008152600401610e33919061525b565b60405180910390fd5b600160675f8381526020019081526020015f205f015f6101000a8154816fffffffffffffffffffffffffffffffff02191690836fffffffffffffffffffffffffffffffff1602179055507f35ab4a1a0e9bec7fd7ae164679b9cc00e6568e4db238d8055a75b1862f62ec2e3382604051610eb7929190615b7a565b60405180910390a15050565b610edb610ece611e8c565b610ed6611e93565b611e9f565b610ee361211b565b565b5f6060805f805f60605f610ef761218a565b90505f801b815f0154148015610f1257505f801b8160010154145b610f51576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610f4890615beb565b60405180910390fd5b610f596121b1565b610f6161224f565b46305f801b5f67ffffffffffffffff811115610f8057610f7f614bc6565b5b604051908082528060200260200182016040528015610fae5781602001602082028036833780820191505090505b507f0f0000000000000000000000000000000000000000000000000000000000000095949392919097509750975097509750975097505090919293949596565b5f80610ff86122ed565b9050805f0160149054906101000a900460ff16611018575f60e01b611021565b638fb3603760e01b5b91505090565b5f5b8282905081101561106c5761106183838381811061104a5761104961583b565b5b905060200281019061105c9190615c0d565b610d19565b806001019050611029565b505050565b60605f805f60655f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16146110fc576040517f9165520100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f8087875f8181106111115761111061583b565b5b90506020028101906111239190615c35565b805f01906111319190615c0d565b60600160208101906111439190615c5c565b90508787905067ffffffffffffffff81111561116257611161614bc6565b5b60405190808252806020026020018201604052801561119b57816020015b61118861497a565b8152602001906001900390816111805790505b5095505f5b888890508110156116fe575f8989838181106111bf576111be61583b565b5b90506020028101906111d19190615c35565b805f01906111df9190615c0d565b6111e890615b68565b90506111f381612314565b611209578361120190615c87565b9350506116f3565b5f61121382610a95565b90505f806fffffffffffffffffffffffffffffffff1660675f8481526020019081526020015f205f015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff16141590505f8115611339575f60016fffffffffffffffffffffffffffffffff1660675f8681526020019081526020015f205f015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff1614905080156112ea57876112de90615c87565b975050505050506116f3565b60675f8581526020019081526020015f205f015f9054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff16915060018203915050611397565b5f6113718e8e888181106113505761134f61583b565b5b90506020028101906113629190615c35565b61136b90615cce565b856123cf565b90508061138e578761138290615c87565b975050505050506116f3565b8460e001519150505b5f6113ca828f8f898181106113af576113ae61583b565b5b90506020028101906113c19190615c35565b60400135612417565b9050808203915060405180604001604052806113e86001850161242d565b6fffffffffffffffffffffffffffffffff16815260200161144b8360675f8981526020019081526020015f205f0160109054906101000a90046fffffffffffffffffffffffffffffffff166fffffffffffffffffffffffffffffffff160161242d565b6fffffffffffffffffffffffffffffffff1681525060675f8681526020019081526020015f205f820151815f015f6101000a8154816fffffffffffffffffffffffffffffffff02191690836fffffffffffffffffffffffffffffffff1602179055506020820151815f0160106101000a8154816fffffffffffffffffffffffffffffffff02191690836fffffffffffffffffffffffffffffffff1602179055509050506114f6614992565b6115008683612490565b825f0183602001828152508281525050508e8e888181106115245761152361583b565b5b90506020028101906115369190615c35565b606001358160200151825f015161154d9190615adb565b1115611585576040517fa28213a300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b8060200151815f01516115989190615adb565b8b6115a39190615adb565b9a5080602001518a6115b59190615adb565b99506040518060400160405280825f01518152602001838152508d88815181106115e2576115e161583b565b5b602002602001018190525061163c8f8f5f8181106116035761160261583b565b5b90506020028101906116159190615c35565b805f01906116239190615c0d565b608001602081019061163591906152a7565b8988612ab6565b611672576040517fffa07f1000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f73ffffffffffffffffffffffffffffffffffffffff168c73ffffffffffffffffffffffffffffffffffffffff16036116ec576116e98f8f898181106116bb576116ba61583b565b5b90506020028101906116cd9190615c35565b805f01906116db9190615c0d565b6116e490615b68565b612ca2565b9b505b5050505050505b8060010190506111a0565b5087879050820361173b576040517f9bc0260d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b505092959194509250565b5f806117506122ed565b9050805f015f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1691505090565b5f611784612f0d565b90505f815f0160089054906101000a900460ff161590505f825f015f9054906101000a900467ffffffffffffffff1690505f808267ffffffffffffffff161480156117cc5750825b90505f60018367ffffffffffffffff161480156117ff57505f3073ffffffffffffffffffffffffffffffffffffffff163b145b90508115801561180d575080155b15611844576040517ff92ee8a900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6001855f015f6101000a81548167ffffffffffffffff021916908367ffffffffffffffff1602179055508315611891576001855f0160086101000a81548160ff0219169083151502179055505b61189a86612f20565b61190e6040518060400160405280601c81526020017f53706563747261204c696d6974204f726465722050726f746f636f6c000000008152506040518060400160405280600181526020017f3100000000000000000000000000000000000000000000000000000000000000815250612f34565b8760665f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508660655f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff16021790555083156119e8575f855f0160086101000a81548160ff0219169083151502179055507fc7f505b2f371ae2175ee4913f4499e1f2633a7b5936321eed1cdaeb6115181d260016040516119df9190615d35565b60405180910390a15b5050505050505050565b611a0a6119fd611e8c565b611a05611e93565b611e9f565b8060655f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508073ffffffffffffffffffffffffffffffffffffffff167f7aed1d3e8155a07ccf395e44ea3109a0e2d6c9b29bbbe9f142d9790596f4dc8060405160405180910390a250565b611a9a6001610b3e565b565b5f815f808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205414905092915050565b611afc611aef611e8c565b611af7611e93565b611e9f565b8060665f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508073ffffffffffffffffffffffffffffffffffffffff167f7a7b5a0a132f9e0581eb8527f66eae9ee89c2a3e79d4ac7e41a1f1f4d48a7fc260405160405180910390a250565b60655f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b5f808260800151905060016004811115611bc457611bc3615940565b5b83606001516004811115611bdb57611bda615940565b5b03611c54578073ffffffffffffffffffffffffffffffffffffffff1663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015611c29573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611c4d9190615d62565b9150611dd6565b60026004811115611c6857611c67615940565b5b83606001516004811115611c7f57611c7e615940565b5b03611c905782608001519150611dd5565b60036004811115611ca457611ca3615940565b5b83606001516004811115611cbb57611cba615940565b5b03611d34578073ffffffffffffffffffffffffffffffffffffffff1663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015611d09573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611d2d9190615d62565b9150611dd4565b600480811115611d4757611d46615940565b5b83606001516004811115611d5e57611d5d615940565b5b03611dd3578073ffffffffffffffffffffffffffffffffffffffff166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa158015611dac573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190611dd09190615d62565b91505b5b5b5b50919050565b5f81510315611e88575f805f805f805f87806020019051810190611e009190615e1a565b96509650965096509650965096508873ffffffffffffffffffffffffffffffffffffffff1663d505accf888888888888886040518863ffffffff1660e01b8152600401611e539796959493929190615ec6565b5f604051808303815f87803b158015611e6a575f80fd5b505af1158015611e7c573d5f803e3d5ffd5b50505050505050505050505b5050565b5f33905090565b365f8036915091509091565b5f611ea86122ed565b90505f80611edc611eb7611746565b873088885f90600492611ecc93929190615f3b565b90611ed79190615f8b565b612f4a565b9150915081611fde575f8163ffffffff161115611fa0576001835f0160146101000a81548160ff021916908315150217905550611f17611746565b73ffffffffffffffffffffffffffffffffffffffff166394c7d7ee8787876040518463ffffffff1660e01b8152600401611f5393929190616025565b5f604051808303815f87803b158015611f6a575f80fd5b505af1158015611f7c573d5f803e3d5ffd5b505050505f835f0160146101000a81548160ff021916908315150217905550611fdd565b856040517f068ca9d8000000000000000000000000000000000000000000000000000000008152600401611fd491906151e3565b60405180910390fd5b5b505050505050565b611fee612fde565b5f611ff761206d565b90505f815f015f6101000a81548160ff0219169083151502179055507f5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa61203c611e8c565b60405161204991906151e3565b60405180910390a150565b5f61206661206061301e565b8361302c565b9050919050565b5f7fcd5ed15c6e187e77e9aee88184c21f4f2182ab5827cb3b7e07fbedcd63f03300905090565b5f61209d6122ed565b905081815f015f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055507f2f658b440c35314f52658ea8a740e05b284cdc84dc9ae01e891f21b8933e7cad8260405161210f91906151e3565b60405180910390a15050565b61212361306c565b5f61212c61206d565b90506001815f015f6101000a81548160ff0219169083151502179055507f62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258612172611e8c565b60405161217f91906151e3565b60405180910390a150565b5f7fa16a46d94261c7517cc8ff89f61c0ce93598e3c849801011dee649a6a557d100905090565b60605f6121bc61218a565b90508060020180546121cd90616082565b80601f01602080910402602001604051908101604052809291908181526020018280546121f990616082565b80156122445780601f1061221b57610100808354040283529160200191612244565b820191905f5260205f20905b81548152906001019060200180831161222757829003601f168201915b505050505091505090565b60605f61225a61218a565b905080600301805461226b90616082565b80601f016020809104026020016040519081016040528092919081815260200182805461229790616082565b80156122e25780601f106122b9576101008083540402835291602001916122e2565b820191905f5260205f20905b8154815290600101906020018083116122c557829003601f168201915b505050505091505090565b5f7ff3177357ab46d8af007ab3fdb9af81da189e1068fefdc0073dca88a2cab40a00905090565b5f42826020015111612328575f90506123ca565b42826080015173ffffffffffffffffffffffffffffffffffffffff1663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa158015612376573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061239a91906160b2565b116123a7575f90506123ca565b6123b98260a001518360400151611a9c565b6123c5575f90506123ca565b600190505b919050565b5f80835f015160a0015190505f813b90505f81036123fd576123f6828587602001516130ad565b925061240f565b61240c82858760200151613159565b92505b505092915050565b5f6124258284108484613278565b905092915050565b5f6fffffffffffffffffffffffffffffffff8016821115612488576080826040517f6dfcc65000000000000000000000000000000000000000000000000000000000815260040161247f929190616116565b60405180910390fd5b819050919050565b5f805f846060015190505f6125a9601261259b886101000151428a6080015173ffffffffffffffffffffffffffffffffffffffff1663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa1580156124f7573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061251b91906160b2565b6125259190615b0e565b8a6080015173ffffffffffffffffffffffffffffffffffffffff1663a1c5b3e16040518163ffffffff1660e01b8152600401602060405180830381865afa158015612572573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061259691906160b2565b613291565b61333590919063ffffffff16565b90505f6126306012886080015173ffffffffffffffffffffffffffffffffffffffff1663efd98dc26040518163ffffffff1660e01b8152600401602060405180830381865afa1580156125fe573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061262291906160b2565b61333590919063ffffffff16565b90505f61263c8861335e565b90505f90506001600481111561265557612654615940565b5b84600481111561266857612667615940565b5b036126f9575f826012600a61267d919061626c565b8561268891906162b6565b6126929190616324565b90506012600a6126a2919061626c565b81896126ae91906162b6565b6126b89190616324565b96505f82146126f357816012600a6126d0919061626c565b836126db9190615b0e565b896126e691906162b6565b6126f09190616324565b95505b50612aab565b6002600481111561270d5761270c615940565b5b8460048111156127205761271f615940565b5b036127be575f836012600a612735919061626c565b8461274091906162b6565b61274a9190616324565b90506012600a61275a919061626c565b818961276691906162b6565b6127709190616324565b96505f82146127b8576012600a612787919061626c565b6012600a612795919061626c565b836127a09190615b0e565b886127ab91906162b6565b6127b59190616324565b95505b50612aaa565b600360048111156127d2576127d1615940565b5b8460048111156127e5576127e4615940565b5b03612909575f8361287060128b6080015173ffffffffffffffffffffffffffffffffffffffff1663a1c5b3e16040518163ffffffff1660e01b8152600401602060405180830381865afa15801561283e573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061286291906160b2565b61333590919063ffffffff16565b61287a9190615b0e565b90505f836012600a61288c919061626c565b8361289791906162b6565b6128a19190616324565b90506012600a6128b1919061626c565b818a6128bd91906162b6565b6128c79190616324565b97505f831461290257816012600a6128df919061626c565b846128ea9190615b0e565b8a6128f591906162b6565b6128ff9190616324565b96505b5050612aa9565b60048081111561291c5761291b615940565b5b84600481111561292f5761292e615940565b5b03612a76575f836129ba60128b6080015173ffffffffffffffffffffffffffffffffffffffff1663a1c5b3e16040518163ffffffff1660e01b8152600401602060405180830381865afa158015612988573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906129ac91906160b2565b61333590919063ffffffff16565b6129c49190615b0e565b90505f816012600a6129d6919061626c565b856129e191906162b6565b6129eb9190616324565b90506012600a6129fb919061626c565b818a612a0791906162b6565b612a119190616324565b97505f8314612a6f57816012600a612a29919061626c565b846012600a612a38919061626c565b86612a439190615b0e565b8b612a4e91906162b6565b612a589190616324565b612a6291906162b6565b612a6c9190616324565b96505b5050612aa8565b6040517f688c176f00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5b5b5b505050509250929050565b5f8373ffffffffffffffffffffffffffffffffffffffff16826080015173ffffffffffffffffffffffffffffffffffffffff1614612af6575f9050612c9b565b60026004811115612b0a57612b09615940565b5b836004811115612b1d57612b1c615940565b5b1480612b4c5750600480811115612b3757612b36615940565b5b836004811115612b4a57612b49615940565b5b145b15612bc25760026004811115612b6557612b64615940565b5b82606001516004811115612b7c57612b7b615940565b5b1480612baf5750600480811115612b9657612b95615940565b5b82606001516004811115612bad57612bac615940565b5b145b15612bbd5760019050612c9b565b612c97565b60016004811115612bd657612bd5615940565b5b836004811115612be957612be8615940565b5b148015612c1e575060016004811115612c0557612c04615940565b5b82606001516004811115612c1c57612c1b615940565b5b145b15612c2c5760019050612c9b565b60036004811115612c4057612c3f615940565b5b836004811115612c5357612c52615940565b5b148015612c88575060036004811115612c6f57612c6e615940565b5b82606001516004811115612c8657612c85615940565b5b145b15612c965760019050612c9b565b5b5f90505b9392505050565b5f808260800151905060016004811115612cbf57612cbe615940565b5b83606001516004811115612cd657612cd5615940565b5b03612ce75782608001519150612f07565b60026004811115612cfb57612cfa615940565b5b83606001516004811115612d1257612d11615940565b5b03612d8b578073ffffffffffffffffffffffffffffffffffffffff1663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612d60573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612d849190615d62565b9150612f06565b60036004811115612d9f57612d9e615940565b5b83606001516004811115612db657612db5615940565b5b03612e2f578073ffffffffffffffffffffffffffffffffffffffff166304aa50ad6040518163ffffffff1660e01b8152600401602060405180830381865afa158015612e04573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612e289190615d62565b9150612f05565b600480811115612e4257612e41615940565b5b83606001516004811115612e5957612e58615940565b5b03612ed2578073ffffffffffffffffffffffffffffffffffffffff1663c644fe946040518163ffffffff1660e01b8152600401602060405180830381865afa158015612ea7573d5f803e3d5ffd5b505050506040513d601f19601f82011682018060405250810190612ecb9190615d62565b9150612f04565b6040517f688c176f00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5b5b5b50919050565b5f80612f176134f3565b90508091505090565b612f2861351c565b612f318161355c565b50565b612f3c61351c565b612f468282613570565b5050565b5f805f858585604051602401612f6293929190616354565b60405160208183030381529060405263b700961360e01b6020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff838183161783525050505090505f80525f60205260405f8251602084018a5afa15612fd4575f51925060205191508160201c15820291505b5094509492505050565b612fe6610b08565b61301c576040517f8dfc202b00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b565b5f6130276135c1565b905090565b5f6040517f190100000000000000000000000000000000000000000000000000000000000081528360028201528260228201526042812091505092915050565b613074610b08565b156130ab576040517fd93c066500000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b565b5f808473ffffffffffffffffffffffffffffffffffffffff163b03613144575f806130d88585613624565b50915091505f60038111156130f0576130ef615940565b5b81600381111561310357613102615940565b5b14801561313b57508573ffffffffffffffffffffffffffffffffffffffff168273ffffffffffffffffffffffffffffffffffffffff16145b92505050613152565b61314f848484613159565b90505b9392505050565b5f805f8573ffffffffffffffffffffffffffffffffffffffff1685856040516024016131869291906163cb565b604051602081830303815290604052631626ba7e60e01b6020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff83818316178352505050506040516131d89190616433565b5f60405180830381855afa9150503d805f8114613210576040519150601f19603f3d011682016040523d82523d5f602084013e613215565b606091505b509150915081801561322957506020815110155b801561326d5750631626ba7e60e01b7bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19168180602001905181019061326b9190616449565b145b925050509392505050565b5f61328284613679565b82841802821890509392505050565b5f806301e133806012600a6132a6919061626c565b856132b191906162b6565b6132bb919061647d565b90505f6012600a6132cc919061626c565b90505f86826132db91906164e5565b90505f6132e782613684565b90505f6133098486846132fa9190616526565b613304919061647d565b613737565b90505f8185896133199190616526565b613323919061647d565b90508096505050505050509392505050565b5f8082601b6133449190615b0e565b600a613350919061626c565b905080840491505092915050565b5f8060655f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16635ab1bd536040518163ffffffff1660e01b8152600401602060405180830381865afa1580156133ca573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906133ee9190615d62565b90505f8173ffffffffffffffffffffffffffffffffffffffff166334b08c056040518163ffffffff1660e01b8152600401602060405180830381865afa15801561343a573d5f803e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061345e91906160b2565b90505f42856080015173ffffffffffffffffffffffffffffffffffffffff1663204f83f96040518163ffffffff1660e01b8152600401602060405180830381865afa1580156134af573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906134d391906160b2565b6134dd9190615b0e565b90506134e98282613d36565b9350505050919050565b5f7ff0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a005f1b905090565b613524613f93565b61355a576040517fd7e6bcf800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b565b61356461351c565b61356d81612094565b50565b61357861351c565b5f61358161218a565b9050828160020190816135949190616724565b50818160030190816135a69190616724565b505f801b815f01819055505f801b8160010181905550505050565b5f7f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f6135eb613fb1565b6135f3614027565b46306040516020016136099594939291906167f3565b60405160208183030381529060405280519060200120905090565b5f805f6041845103613664575f805f602087015192506040870151915060608701515f1a90506136568882858561409e565b955095509550505050613672565b5f600285515f1b9250925092505b9250925092565b5f8115159050919050565b5f8082136136c7576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016136be9061688e565b60405180910390fd5b8167016345785d8a0000670de0b6b3a7640000031280156136f9575067016345785d8a0000670de0b6b3a76400000182125b1561372657670de0b6b3a764000061371083614185565b8161371e5761371d6162f7565b5b059050613732565b61372f8261439d565b90505b919050565b5f7ffffffffffffffffffffffffffffffffffffffffffffffffdc702bd3a30fc00008212158015613771575068070c1cc73b00c800008213155b6137b0576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004016137a7906168f6565b60405180910390fd5b5f8212156137e4576137c3825f03613737565b670de0b6b3a76400008002816137dc576137db6162f7565b5b059050613d31565b5f6806f05b59d3b20000008312613823576806f05b59d3b200000083039250770195e54c5dd42177f53a27172fa9ec630262827000000000905061385b565b6803782dace9d90000008312613855576803782dace9d9000000830392506b1425982cf597cd205cef7380905061385a565b600190505b5b6064830292505f68056bc75e2d63100000905068ad78ebc5ac6200000084126138ba5768ad78ebc5ac620000008403935068056bc75e2d631000006e01855144814a7ff805980ff00840008202816138b6576138b56162f7565b5b0590505b6856bc75e2d6310000008412613903576856bc75e2d6310000008403935068056bc75e2d631000006b02df0ab5a80a22c61ab5a7008202816138ff576138fe6162f7565b5b0590505b682b5e3af16b18800000841261394a57682b5e3af16b188000008403935068056bc75e2d63100000693f1fce3da636ea5cf850820281613946576139456162f7565b5b0590505b6815af1d78b58c4000008412613991576815af1d78b58c4000008403935068056bc75e2d63100000690127fa27722cc06cc5e282028161398d5761398c6162f7565b5b0590505b680ad78ebc5ac620000084126139d757680ad78ebc5ac62000008403935068056bc75e2d6310000068280e60114edb805d038202816139d3576139d26162f7565b5b0590505b68056bc75e2d631000008412613a1d5768056bc75e2d631000008403935068056bc75e2d63100000680ebc5fb41746121110820281613a1957613a186162f7565b5b0590505b6802b5e3af16b18800008412613a63576802b5e3af16b18800008403935068056bc75e2d631000006808f00f760a4b2db55d820281613a5f57613a5e6162f7565b5b0590505b68015af1d78b58c400008412613aa95768015af1d78b58c400008403935068056bc75e2d631000006806f5f1775788937937820281613aa557613aa46162f7565b5b0590505b5f68056bc75e2d6310000090505f8590508082019150600268056bc75e2d6310000087830281613adc57613adb6162f7565b5b0581613aeb57613aea6162f7565b5b0590508082019150600368056bc75e2d6310000087830281613b1057613b0f6162f7565b5b0581613b1f57613b1e6162f7565b5b0590508082019150600468056bc75e2d6310000087830281613b4457613b436162f7565b5b0581613b5357613b526162f7565b5b0590508082019150600568056bc75e2d6310000087830281613b7857613b776162f7565b5b0581613b8757613b866162f7565b5b0590508082019150600668056bc75e2d6310000087830281613bac57613bab6162f7565b5b0581613bbb57613bba6162f7565b5b0590508082019150600768056bc75e2d6310000087830281613be057613bdf6162f7565b5b0581613bef57613bee6162f7565b5b0590508082019150600868056bc75e2d6310000087830281613c1457613c136162f7565b5b0581613c2357613c226162f7565b5b0590508082019150600968056bc75e2d6310000087830281613c4857613c476162f7565b5b0581613c5757613c566162f7565b5b0590508082019150600a68056bc75e2d6310000087830281613c7c57613c7b6162f7565b5b0581613c8b57613c8a6162f7565b5b0590508082019150600b68056bc75e2d6310000087830281613cb057613caf6162f7565b5b0581613cbf57613cbe6162f7565b5b0590508082019150600c68056bc75e2d6310000087830281613ce457613ce36162f7565b5b0581613cf357613cf26162f7565b5b059050808201915060648468056bc75e2d6310000084860281613d1957613d186162f7565b5b050281613d2957613d286162f7565b5b059450505050505b919050565b5f808203613d4e57670de0b6b3a76400009050613f8d565b5f8303613d5d575f9050613f8d565b7f80000000000000000000000000000000000000000000000000000000000000008310613dbf576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401613db69061695e565b60405180910390fd5b5f83905068056bc75e2d631000007f400000000000000000000000000000000000000000000000000000000000000081613dfc57613dfb6162f7565b5b048310613e3e576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401613e35906169c6565b60405180910390fd5b5f8390505f8267016345785d8a0000670de0b6b3a764000003128015613e75575067016345785d8a0000670de0b6b3a76400000183125b15613edd575f613e8484614185565b9050670de0b6b3a764000083670de0b6b3a76400008381613ea857613ea76162f7565b5b070281613eb857613eb76162f7565b5b0583670de0b6b3a76400008381613ed257613ed16162f7565b5b050201915050613eeb565b81613ee78461439d565b0290505b670de0b6b3a76400008181613f0357613f026162f7565b5b059050807ffffffffffffffffffffffffffffffffffffffffffffffffdc702bd3a30fc000013158015613f3f575068070c1cc73b00c800008113155b613f7e576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401613f7590616a2e565b60405180910390fd5b613f8781613737565b93505050505b92915050565b5f613f9c612f0d565b5f0160089054906101000a900460ff16905090565b5f80613fbb61218a565b90505f613fc66121b1565b90505f81511115613fe257808051906020012092505050614024565b5f825f015490505f801b8114613ffd57809350505050614024565b7fc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a47093505050505b90565b5f8061403161218a565b90505f61403c61224f565b90505f815111156140585780805190602001209250505061409b565b5f826001015490505f801b81146140745780935050505061409b565b7fc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a47093505050505b90565b5f805f7f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0845f1c11156140da575f60038592509250925061417b565b5f6001888888886040515f81526020016040526040516140fd9493929190616a4c565b6020604051602081039080840390855afa15801561411d573d5f803e3d5ffd5b5050506020604051035190505f73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff160361416e575f60015f801b9350935093505061417b565b805f805f1b935093509350505b9450945094915050565b5f670de0b6b3a7640000820291505f6ec097ce7bc90715b34b9f100000000083016ec097ce7bc90715b34b9f100000000080850302816141c8576141c76162f7565b5b0590505f6ec097ce7bc90715b34b9f1000000000828302816141ed576141ec6162f7565b5b0590505f8290505f8190506ec097ce7bc90715b34b9f100000000083830281614219576142186162f7565b5b0591506003828161422d5761422c6162f7565b5b05810190506ec097ce7bc90715b34b9f100000000083830281614253576142526162f7565b5b05915060058281614267576142666162f7565b5b05810190506ec097ce7bc90715b34b9f10000000008383028161428d5761428c6162f7565b5b059150600782816142a1576142a06162f7565b5b05810190506ec097ce7bc90715b34b9f1000000000838302816142c7576142c66162f7565b5b059150600982816142db576142da6162f7565b5b05810190506ec097ce7bc90715b34b9f100000000083830281614301576143006162f7565b5b059150600b8281614315576143146162f7565b5b05810190506ec097ce7bc90715b34b9f10000000008383028161433b5761433a6162f7565b5b059150600d828161434f5761434e6162f7565b5b05810190506ec097ce7bc90715b34b9f100000000083830281614375576143746162f7565b5b059150600f8281614389576143886162f7565b5b058101905060028102945050505050919050565b5f670de0b6b3a76400008212156143da576143d182670de0b6b3a76400008002816143cb576143ca6162f7565b5b0561439d565b5f0390506148de565b5f670de0b6b3a7640000770195e54c5dd42177f53a27172fa9ec63026282700000000002831261443e57770195e54c5dd42177f53a27172fa9ec630262827000000000838161442c5761442b6162f7565b5b0592506806f05b59d3b2000000810190505b670de0b6b3a76400006b1425982cf597cd205cef7380028312614489576b1425982cf597cd205cef73808381614477576144766162f7565b5b0592506803782dace9d9000000810190505b6064810290506064830292506e01855144814a7ff805980ff008400083126144e7576e01855144814a7ff805980ff008400068056bc75e2d631000008402816144d5576144d46162f7565b5b05925068ad78ebc5ac62000000810190505b6b02df0ab5a80a22c61ab5a7008312614533576b02df0ab5a80a22c61ab5a70068056bc75e2d63100000840281614521576145206162f7565b5b0592506856bc75e2d631000000810190505b693f1fce3da636ea5cf850831261457b57693f1fce3da636ea5cf85068056bc75e2d63100000840281614569576145686162f7565b5b059250682b5e3af16b18800000810190505b690127fa27722cc06cc5e283126145c357690127fa27722cc06cc5e268056bc75e2d631000008402816145b1576145b06162f7565b5b0592506815af1d78b58c400000810190505b68280e60114edb805d0383126146095768280e60114edb805d0368056bc75e2d631000008402816145f7576145f66162f7565b5b059250680ad78ebc5ac6200000810190505b680ebc5fb41746121110831261464f57680ebc5fb4174612111068056bc75e2d6310000084028161463d5761463c6162f7565b5b05925068056bc75e2d63100000810190505b6808f00f760a4b2db55d8312614695576808f00f760a4b2db55d68056bc75e2d63100000840281614683576146826162f7565b5b0592506802b5e3af16b1880000810190505b6806f5f177578893793783126146db576806f5f177578893793768056bc75e2d631000008402816146c9576146c86162f7565b5b05925068015af1d78b58c40000810190505b6806248f33704b2866038312614720576806248f33704b28660368056bc75e2d6310000084028161470f5761470e6162f7565b5b05925067ad78ebc5ac620000810190505b6805c548670b9510e7ac8312614765576805c548670b9510e7ac68056bc75e2d63100000840281614754576147536162f7565b5b0592506756bc75e2d6310000810190505b5f68056bc75e2d63100000840168056bc75e2d63100000808603028161478e5761478d6162f7565b5b0590505f68056bc75e2d63100000828302816147ad576147ac6162f7565b5b0590505f8290505f81905068056bc75e2d63100000838302816147d3576147d26162f7565b5b059150600382816147e7576147e66162f7565b5b058101905068056bc75e2d6310000083830281614807576148066162f7565b5b0591506005828161481b5761481a6162f7565b5b058101905068056bc75e2d631000008383028161483b5761483a6162f7565b5b0591506007828161484f5761484e6162f7565b5b058101905068056bc75e2d631000008383028161486f5761486e6162f7565b5b05915060098281614883576148826162f7565b5b058101905068056bc75e2d63100000838302816148a3576148a26162f7565b5b059150600b82816148b7576148b66162f7565b5b05810190506002810290506064818601816148d5576148d46162f7565b5b05955050505050505b919050565b6040518061012001604052805f81526020015f81526020015f81526020015f600481111561491457614913615940565b5b81526020015f73ffffffffffffffffffffffffffffffffffffffff1681526020015f73ffffffffffffffffffffffffffffffffffffffff1681526020015f73ffffffffffffffffffffffffffffffffffffffff1681526020015f81526020015f81525090565b60405180604001604052805f81526020015f81525090565b60405180604001604052805f81526020015f81525090565b5f604051905090565b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f80fd5b5f8083601f8401126149dc576149db6149bb565b5b8235905067ffffffffffffffff8111156149f9576149f86149bf565b5b602083019150836020820283011115614a1557614a146149c3565b5b9250929050565b5f8060208385031215614a3257614a316149b3565b5b5f83013567ffffffffffffffff811115614a4f57614a4e6149b7565b5b614a5b858286016149c7565b92509250509250929050565b5f81519050919050565b5f82825260208201905092915050565b5f819050602082019050919050565b5f819050919050565b614aa281614a90565b82525050565b5f614ab38383614a99565b60208301905092915050565b5f602082019050919050565b5f614ad582614a67565b614adf8185614a71565b9350614aea83614a81565b805f5b83811015614b1a578151614b018882614aa8565b9750614b0c83614abf565b925050600181019050614aed565b5085935050505092915050565b5f6040820190508181035f830152614b3f8185614acb565b90508181036020830152614b538184614acb565b90509392505050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f614b8582614b5c565b9050919050565b614b9581614b7b565b8114614b9f575f80fd5b50565b5f81359050614bb081614b8c565b92915050565b5f601f19601f8301169050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b614bfc82614bb6565b810181811067ffffffffffffffff82111715614c1b57614c1a614bc6565b5b80604052505050565b5f614c2d6149aa565b9050614c398282614bf3565b919050565b5f67ffffffffffffffff821115614c5857614c57614bc6565b5b602082029050602081019050919050565b5f80fd5b5f80fd5b614c7a81614a90565b8114614c84575f80fd5b50565b5f81359050614c9581614c71565b92915050565b60058110614ca7575f80fd5b50565b5f81359050614cb881614c9b565b92915050565b5f80fd5b5f67ffffffffffffffff821115614cdc57614cdb614bc6565b5b614ce582614bb6565b9050602081019050919050565b828183375f83830152505050565b5f614d12614d0d84614cc2565b614c24565b905082815260208101848484011115614d2e57614d2d614cbe565b5b614d39848285614cf2565b509392505050565b5f82601f830112614d5557614d546149bb565b5b8135614d65848260208601614d00565b91505092915050565b5f6101408284031215614d8457614d83614c69565b5b614d8f610140614c24565b90505f614d9e84828501614c87565b5f830152506020614db184828501614c87565b6020830152506040614dc584828501614c87565b6040830152506060614dd984828501614caa565b6060830152506080614ded84828501614ba2565b60808301525060a0614e0184828501614ba2565b60a08301525060c0614e1584828501614ba2565b60c08301525060e0614e2984828501614c87565b60e083015250610100614e3e84828501614c87565b6101008301525061012082013567ffffffffffffffff811115614e6457614e63614c6d565b5b614e7084828501614d41565b6101208301525092915050565b5f60808284031215614e9257614e91614c69565b5b614e9c6080614c24565b90505f82013567ffffffffffffffff811115614ebb57614eba614c6d565b5b614ec784828501614d6e565b5f83015250602082013567ffffffffffffffff811115614eea57614ee9614c6d565b5b614ef684828501614d41565b6020830152506040614f0a84828501614c87565b6040830152506060614f1e84828501614c87565b60608301525092915050565b5f614f3c614f3784614c3e565b614c24565b90508083825260208201905060208402830185811115614f5f57614f5e6149c3565b5b835b81811015614fa657803567ffffffffffffffff811115614f8457614f836149bb565b5b808601614f918982614e7d565b85526020850194505050602081019050614f61565b5050509392505050565b5f82601f830112614fc457614fc36149bb565b5b8135614fd4848260208601614f2a565b91505092915050565b5f67ffffffffffffffff821115614ff757614ff6614bc6565b5b602082029050602081019050919050565b5f6040828403121561501d5761501c614c69565b5b6150276040614c24565b90505f61503684828501614c87565b5f83015250602061504984828501614c87565b60208301525092915050565b5f61506761506284614fdd565b614c24565b9050808382526020820190506040840283018581111561508a576150896149c3565b5b835b818110156150b3578061509f8882615008565b84526020840193505060408101905061508c565b5050509392505050565b5f82601f8301126150d1576150d06149bb565b5b81356150e1848260208601615055565b91505092915050565b5f6150f482614b7b565b9050919050565b615104816150ea565b811461510e575f80fd5b50565b5f8135905061511f816150fb565b92915050565b5f805f805f60a0868803121561513e5761513d6149b3565b5b5f61514b88828901614ba2565b955050602086013567ffffffffffffffff81111561516c5761516b6149b7565b5b61517888828901614fb0565b945050604086013567ffffffffffffffff811115615199576151986149b7565b5b6151a5888289016150bd565b93505060606151b688828901615111565b92505060806151c788828901614c87565b9150509295509295909350565b6151dd81614b7b565b82525050565b5f6020820190506151f65f8301846151d4565b92915050565b5f60208284031215615211576152106149b3565b5b5f82013567ffffffffffffffff81111561522e5761522d6149b7565b5b61523a84828501614d6e565b91505092915050565b5f819050919050565b61525581615243565b82525050565b5f60208201905061526e5f83018461524c565b92915050565b5f8115159050919050565b61528881615274565b82525050565b5f6020820190506152a15f83018461527f565b92915050565b5f602082840312156152bc576152bb6149b3565b5b5f6152c984828501614ba2565b91505092915050565b6152db81614a90565b82525050565b5f6020820190506152f45f8301846152d2565b92915050565b5f60ff82169050919050565b61530f816152fa565b8114615319575f80fd5b50565b5f8135905061532a81615306565b92915050565b5f60208284031215615345576153446149b3565b5b5f6153528482850161531c565b91505092915050565b5f80fd5b5f61014082840312156153755761537461535b565b5b81905092915050565b5f60208284031215615393576153926149b3565b5b5f82013567ffffffffffffffff8111156153b0576153af6149b7565b5b6153bc8482850161535f565b91505092915050565b5f7fff0000000000000000000000000000000000000000000000000000000000000082169050919050565b6153f9816153c5565b82525050565b5f81519050919050565b5f82825260208201905092915050565b5f5b8381101561543657808201518184015260208101905061541b565b5f8484015250505050565b5f61544b826153ff565b6154558185615409565b9350615465818560208601615419565b61546e81614bb6565b840191505092915050565b5f60e08201905061548c5f83018a6153f0565b818103602083015261549e8189615441565b905081810360408301526154b28188615441565b90506154c160608301876152d2565b6154ce60808301866151d4565b6154db60a083018561524c565b81810360c08301526154ed8184614acb565b905098975050505050505050565b5f7fffffffff0000000000000000000000000000000000000000000000000000000082169050919050565b61552f816154fb565b82525050565b5f6020820190506155485f830184615526565b92915050565b5f8083601f840112615563576155626149bb565b5b8235905067ffffffffffffffff8111156155805761557f6149bf565b5b60208301915083602082028301111561559c5761559b6149c3565b5b9250929050565b5f80602083850312156155b9576155b86149b3565b5b5f83013567ffffffffffffffff8111156155d6576155d56149b7565b5b6155e28582860161554e565b92509250509250929050565b5f8083601f840112615603576156026149bb565b5b8235905067ffffffffffffffff8111156156205761561f6149bf565b5b60208301915083602082028301111561563c5761563b6149c3565b5b9250929050565b5f8060208385031215615659576156586149b3565b5b5f83013567ffffffffffffffff811115615676576156756149b7565b5b615682858286016155ee565b92509250509250929050565b5f81519050919050565b5f82825260208201905092915050565b5f819050602082019050919050565b604082015f8201516156cb5f850182614a99565b5060208201516156de6020850182614a99565b50505050565b5f6156ef83836156b7565b60408301905092915050565b5f602082019050919050565b5f6157118261568e565b61571b8185615698565b9350615726836156a8565b805f5b8381101561575657815161573d88826156e4565b9750615748836156fb565b925050600181019050615729565b5085935050505092915050565b5f6080820190508181035f83015261577b8187615707565b905061578a60208301866151d4565b61579760408301856152d2565b6157a460608301846152d2565b95945050505050565b5f805f606084860312156157c4576157c36149b3565b5b5f6157d186828701614ba2565b93505060206157e286828701614ba2565b92505060406157f386828701614ba2565b9150509250925092565b5f8060408385031215615813576158126149b3565b5b5f61582085828601614ba2565b925050602061583185828601614c87565b9150509250929050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffd5b5f60608201905061587b5f8301866151d4565b61588860208301856151d4565b61589560408301846152d2565b949350505050565b6158a681615274565b81146158b0575f80fd5b50565b5f815190506158c18161589d565b92915050565b5f602082840312156158dc576158db6149b3565b5b5f6158e9848285016158b3565b91505092915050565b5f6040820190506159055f8301856151d4565b61591260208301846152d2565b9392505050565b5f60408201905061592c5f83018561524c565b61593960208301846152d2565b9392505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b6005811061597e5761597d615940565b5b50565b5f81905061598e8261596d565b919050565b5f61599d82615981565b9050919050565b6159ad81615993565b82525050565b6159bc81614b7b565b82525050565b61012082015f8201516159d75f850182614a99565b5060208201516159ea6020850182614a99565b5060408201516159fd6040850182614a99565b506060820151615a1060608501826159a4565b506080820151615a2360808501826159b3565b5060a0820151615a3660a08501826159b3565b5060c0820151615a4960c08501826159b3565b5060e0820151615a5c60e0850182614a99565b50610100820151615a71610100850182614a99565b50505050565b5f61016082019050615a8b5f83018661524c565b615a9860208301856159c2565b615aa661014083018461524c565b949350505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f615ae582614a90565b9150615af083614a90565b9250828201905080821115615b0857615b07615aae565b5b92915050565b5f615b1882614a90565b9150615b2383614a90565b9250828203905081811115615b3b57615b3a615aae565b5b92915050565b5f604082019050615b545f8301856152d2565b615b6160208301846152d2565b9392505050565b5f615b733683614d6e565b9050919050565b5f604082019050615b8d5f8301856151d4565b615b9a602083018461524c565b9392505050565b7f4549503731323a20556e696e697469616c697a656400000000000000000000005f82015250565b5f615bd5601583615409565b9150615be082615ba1565b602082019050919050565b5f6020820190508181035f830152615c0281615bc9565b9050919050565b5f80fd5b5f8235600161014003833603038112615c2957615c28615c09565b5b80830191505092915050565b5f82356001608003833603038112615c5057615c4f615c09565b5b80830191505092915050565b5f60208284031215615c7157615c706149b3565b5b5f615c7e84828501614caa565b91505092915050565b5f615c9182614a90565b91507fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8203615cc357615cc2615aae565b5b600182019050919050565b5f615cd93683614e7d565b9050919050565b5f819050919050565b5f67ffffffffffffffff82169050919050565b5f819050919050565b5f615d1f615d1a615d1584615ce0565b615cfc565b615ce9565b9050919050565b615d2f81615d05565b82525050565b5f602082019050615d485f830184615d26565b92915050565b5f81519050615d5c81614b8c565b92915050565b5f60208284031215615d7757615d766149b3565b5b5f615d8484828501615d4e565b91505092915050565b5f615d9782614b5c565b9050919050565b615da781615d8d565b8114615db1575f80fd5b50565b5f81519050615dc281615d9e565b92915050565b5f81519050615dd681614c71565b92915050565b5f81519050615dea81615306565b92915050565b615df981615243565b8114615e03575f80fd5b50565b5f81519050615e1481615df0565b92915050565b5f805f805f805f60e0888a031215615e3557615e346149b3565b5b5f615e428a828b01615db4565b9750506020615e538a828b01615db4565b9650506040615e648a828b01615dc8565b9550506060615e758a828b01615dc8565b9450506080615e868a828b01615ddc565b93505060a0615e978a828b01615e06565b92505060c0615ea88a828b01615e06565b91505092959891949750929550565b615ec0816152fa565b82525050565b5f60e082019050615ed95f83018a6151d4565b615ee660208301896151d4565b615ef360408301886152d2565b615f0060608301876152d2565b615f0d6080830186615eb7565b615f1a60a083018561524c565b615f2760c083018461524c565b98975050505050505050565b5f80fd5b5f80fd5b5f8085851115615f4e57615f4d615f33565b5b83861115615f5f57615f5e615f37565b5b6001850283019150848603905094509492505050565b5f82905092915050565b5f82821b905092915050565b5f615f968383615f75565b82615fa181356154fb565b92506004821015615fe157615fdc7fffffffff0000000000000000000000000000000000000000000000000000000083600403600802615f7f565b831692505b505092915050565b5f82825260208201905092915050565b5f6160048385615fe9565b9350616011838584614cf2565b61601a83614bb6565b840190509392505050565b5f6040820190506160385f8301866151d4565b818103602083015261604b818486615ff9565b9050949350505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f600282049050600182168061609957607f821691505b6020821081036160ac576160ab616055565b5b50919050565b5f602082840312156160c7576160c66149b3565b5b5f6160d484828501615dc8565b91505092915050565b5f819050919050565b5f6161006160fb6160f6846160dd565b615cfc565b6152fa565b9050919050565b616110816160e6565b82525050565b5f6040820190506161295f830185616107565b61613660208301846152d2565b9392505050565b5f8160011c9050919050565b5f808291508390505b60018511156161925780860481111561616e5761616d615aae565b5b600185161561617d5780820291505b808102905061618b8561613d565b9450616152565b94509492505050565b5f826161aa5760019050616265565b816161b7575f9050616265565b81600181146161cd57600281146161d757616206565b6001915050616265565b60ff8411156161e9576161e8615aae565b5b8360020a915084821115616200576161ff615aae565b5b50616265565b5060208310610133831016604e8410600b841016171561623b5782820a90508381111561623657616235615aae565b5b616265565b6162488484846001616149565b9250905081840481111561625f5761625e615aae565b5b81810290505b9392505050565b5f61627682614a90565b915061628183614a90565b92506162ae7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff848461619b565b905092915050565b5f6162c082614a90565b91506162cb83614a90565b92508282026162d981614a90565b915082820484148315176162f0576162ef615aae565b5b5092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601260045260245ffd5b5f61632e82614a90565b915061633983614a90565b925082616349576163486162f7565b5b828204905092915050565b5f6060820190506163675f8301866151d4565b61637460208301856151d4565b6163816040830184615526565b949350505050565b5f81519050919050565b5f61639d82616389565b6163a78185615fe9565b93506163b7818560208601615419565b6163c081614bb6565b840191505092915050565b5f6040820190506163de5f83018561524c565b81810360208301526163f08184616393565b90509392505050565b5f81905092915050565b5f61640d82616389565b61641781856163f9565b9350616427818560208601615419565b80840191505092915050565b5f61643e8284616403565b915081905092915050565b5f6020828403121561645e5761645d6149b3565b5b5f61646b84828501615e06565b91505092915050565b5f819050919050565b5f61648782616474565b915061649283616474565b9250826164a2576164a16162f7565b5b60015f0383147f8000000000000000000000000000000000000000000000000000000000000000831416156164da576164d9615aae565b5b828205905092915050565b5f6164ef82616474565b91506164fa83616474565b92508282019050828112155f8312168382125f8412151617156165205761651f615aae565b5b92915050565b5f61653082616474565b915061653b83616474565b925082820261654981616474565b91507f800000000000000000000000000000000000000000000000000000000000000084145f841216156165805761657f615aae565b5b828205841483151761659557616594615aae565b5b5092915050565b5f819050815f5260205f209050919050565b5f6020601f8301049050919050565b5f600883026165ec7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82615f7f565b6165f68683615f7f565b95508019841693508086168417925050509392505050565b5f61662861662361661e84614a90565b615cfc565b614a90565b9050919050565b5f819050919050565b6166418361660e565b61665561664d8261662f565b8484546165bd565b825550505050565b5f90565b61666961665d565b616674818484616638565b505050565b5b818110156166975761668c5f82616661565b60018101905061667a565b5050565b601f8211156166dc576166ad8161659c565b6166b6846165ae565b810160208510156166c5578190505b6166d96166d1856165ae565b830182616679565b50505b505050565b5f82821c905092915050565b5f6166fc5f19846008026166e1565b1980831691505092915050565b5f61671483836166ed565b9150826002028217905092915050565b61672d826153ff565b67ffffffffffffffff81111561674657616745614bc6565b5b6167508254616082565b61675b82828561669b565b5f60209050601f83116001811461678c575f841561677a578287015190505b6167848582616709565b8655506167eb565b601f19841661679a8661659c565b5f5b828110156167c15784890151825560018201915060208501945060208101905061679c565b868310156167de57848901516167da601f8916826166ed565b8355505b6001600288020188555050505b505050505050565b5f60a0820190506168065f83018861524c565b616813602083018761524c565b616820604083018661524c565b61682d60608301856152d2565b61683a60808301846151d4565b9695505050505050565b7f6f7574206f6620626f756e6473000000000000000000000000000000000000005f82015250565b5f616878600d83615409565b915061688382616844565b602082019050919050565b5f6020820190508181035f8301526168a58161686c565b9050919050565b7f496e76616c6964206578706f6e656e74000000000000000000000000000000005f82015250565b5f6168e0601083615409565b91506168eb826168ac565b602082019050919050565b5f6020820190508181035f83015261690d816168d4565b9050919050565b7f78206f7574206f6620626f756e647300000000000000000000000000000000005f82015250565b5f616948600f83615409565b915061695382616914565b602082019050919050565b5f6020820190508181035f8301526169758161693c565b9050919050565b7f79206f7574206f6620626f756e647300000000000000000000000000000000005f82015250565b5f6169b0600f83615409565b91506169bb8261697c565b602082019050919050565b5f6020820190508181035f8301526169dd816169a4565b9050919050565b7f70726f64756374206f7574206f6620626f756e647300000000000000000000005f82015250565b5f616a18601583615409565b9150616a23826169e4565b602082019050919050565b5f6020820190508181035f830152616a4581616a0c565b9050919050565b5f608082019050616a5f5f83018761524c565b616a6c6020830186615eb7565b616a79604083018561524c565b616a86606083018461524c565b9594505050505056fea2646970667358221220f015e1bff79b818a06cae08a4757548a7c3d4b969235a1163efb8715e6be426964736f6c63430008180033",
-      "sourceMap":"1530:19259:131:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5152:500;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;;;;;;;:::i;:::-;;;;;;;;10514:1050;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;4562:531;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;;;;;;;:::i;:::-;;;;;;;;3914:66;;;:::i;:::-;;2371:27;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;4167:336;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;2496:145:64;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;233:40:132;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;474:213;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;4069:362:57;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;6060:424:131;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;3846:62;;;:::i;:::-;;5048:903:66;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;;;;;;;;4472:227:57;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;5842:159:131;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;6660:3495;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;;;;;;;;;:::i;:::-;;;;;;;;3864:164:57;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;3082:318:131;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;3534:132;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;351:66:132;;;:::i;:::-;;845:147;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;3672:168:131;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;2344:21;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;5152:500;5244:27;5273:30;5345:29;5362:11;;5345:16;:29::i;:::-;5315:59;;;;;;;;5389:9;5384:262;5408:10;:17;5404:1;:21;5384:262;;;1889:1;5450:38;;:10;5461:1;5450:13;;;;;;;;:::i;:::-;;;;;;;;:38;5446:116;;5532:11;;5544:1;5532:14;;;;;;;:::i;:::-;;;;;;;;5515:32;;;;;;;;;;;:::i;:::-;;;;;;;;5446:116;5620:1;5603:10;5614:1;5603:13;;;;;;;;:::i;:::-;;;;;;;:18;;;;;;;;;;;5427:3;;;;;;;5384:262;;;;5152:500;;;;;:::o;10514:1050::-;2608:6;;;;;;;;;;;2594:20;;:10;:20;;;2590:69;;2637:11;;;;;;;;;;;;;;2590:69;10754:6:::1;10750:754;10765:16;:23;10762:1;:26;10750:754;;;10848:1;10812:16;10829:1;10812:19;;;;;;;;:::i;:::-;;;;;;;;:32;;;:37:::0;10808:83;10868:8:::1;10808:83;10904:36;10943:6;10950:1;10943:9;;;;;;;;:::i;:::-;;;;;;;;:15;;;10904:54;;10985:17;11012:22;11028:5;11012:15;:22::i;:::-;10985:50;;11049:47;11070:10;11083:5;:12;;;11049;:47::i;:::-;11168:10;:23;;;11192:5;:11;;;11205:8;11215:16;11232:1;11215:19;;;;;;;;:::i;:::-;;;;;;;;:32;;;11168:80;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;11342:10;:19;;;11362:5;:14;;;11378:16;11395:1;11378:19;;;;;;;;:::i;:::-;;;;;;;;:32;;;11342:69;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;11430:63;11442:16;11452:5;11442:9;:16::i;:::-;11460;11477:1;11460:19;;;;;;;;:::i;:::-;;;;;;;;:32;;;11430:63;;;;;;;:::i;:::-;;;;;;;;10794:710;;10750:754;10790:3;;;;;10750:754;;;;11513:10;:19;;;11533:12;;;;;;;;;;;11547:9;11513:44;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;10514:1050:::0;;;;;:::o;4562:531::-;4655:30;4687;4729:11;4743;;:18;;4729:32;;4801:3;4787:18;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4771:34;;4845:3;4831:18;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4815:34;;4865:9;4860:227;4884:3;4880:1;:7;4860:227;;;4908:43;4954:14;:30;4969:11;;4981:1;4969:14;;;;;;;:::i;:::-;;;;;;;;4954:30;;;;;;;;;;;4908:76;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5038:6;:16;;;5056:6;:19;;;4998:78;;;;;;;;;;4999:13;5013:1;4999:16;;;;;;;;:::i;:::-;;;;;;;5017:13;5031:1;5017:16;;;;;;;;:::i;:::-;;;;;;;4998:78;;;;;;;;;;4894:193;4889:3;;;;;;;4860:227;;;;4719:374;4562:531;;;;;:::o;3914:66::-;3766:39:57;3780:12;:10;:12::i;:::-;3794:10;:8;:10::i;:::-;3766:13;:39::i;:::-;3963:10:131::1;:8;:10::i;:::-;3914:66::o:0;2371:27::-;;;;;;;;;;;;;:::o;4167:336::-;4227:7;4246:30;;:::i;:::-;4324:5;4309:20;;4367:129;2110:227;4444:11;4467:5;:12;;;4457:23;;;;;;4411:70;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;4401:81;;;;;;4367:16;:129::i;:::-;4348:148;;;4167:336;;;:::o;2496:145:64:-;2543:4;2559:25;2587:21;:19;:21::i;:::-;2559:49;;2625:1;:9;;;;;;;;;;;;2618:16;;;2496:145;:::o;233:40:132:-;;;;;;;;;;;;;;;;;:::o;474:213::-;527:16;566:6;546:26;;:5;:17;552:10;546:17;;;;;;;;;;;;;;;;:26;;;;:::i;:::-;527:45;;602:8;582:5;:17;588:10;582:17;;;;;;;;;;;;;;;:28;;;;640:10;625:55;;;663:6;652:17;;:8;:17;;;;:::i;:::-;671:8;625:55;;;;;;;:::i;:::-;;;;;;;;517:170;474:213;:::o;4069:362:57:-;4138:14;4155:12;:10;:12::i;:::-;4138:29;;4191:11;:9;:11::i;:::-;4181:21;;:6;:21;;;4177:92;;4251:6;4225:33;;;;;;;;;;;:::i;:::-;;;;;;;;4177:92;4310:1;4282:12;:24;;;:29;4278:110;;4364:12;4334:43;;;;;;;;;;;:::i;:::-;;;;;;;;4278:110;4397:27;4411:12;4397:13;:27::i;:::-;4128:303;4069:362;:::o;6060:424:131:-;6140:10;6125:25;;:5;:11;;;;;;;;;;:::i;:::-;:25;;;6121:73;;6173:10;;;;;;;;;;;;;;6121:73;6204:17;6224:16;6234:5;6224:16;;;:::i;:::-;:9;:16::i;:::-;6204:36;;1938:1;6254:52;;:14;:25;6269:9;6254:25;;;;;;;;;;;:35;;;;;;;;;;;;:52;;;6250:114;;6343:9;6329:24;;;;;;;;;;;:::i;:::-;;;;;;;;6250:114;1938:1;6374:14;:25;6389:9;6374:25;;;;;;;;;;;:35;;;:51;;;;;;;;;;;;;;;;;;6441:36;6455:10;6467:9;6441:36;;;;;;;:::i;:::-;;;;;;;;6111:373;6060:424;:::o;3846:62::-;3766:39:57;3780:12;:10;:12::i;:::-;3794:10;:8;:10::i;:::-;3766:13;:39::i;:::-;3893:8:131::1;:6;:8::i;:::-;3846:62::o:0;5048:903:66:-;5146:13;5173:18;5205:21;5240:15;5269:25;5308:12;5334:27;5386:23;5412:19;:17;:19::i;:::-;5386:45;;5669:1;5652:18;;:1;:13;;;:18;:43;;;;;5694:1;5674:21;;:1;:16;;;:21;5652:43;5644:77;;;;;;;;;;;;:::i;:::-;;;;;;;;;5783:13;:11;:13::i;:::-;5810:16;:14;:16::i;:::-;5840:13;5875:4;5902:1;5894:10;;5932:1;5918:16;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5732:212;;;;;;;;;;;;;;;;;;;;;;5048:903;;;;;;;:::o;4472:227:57:-;4527:6;4545:30;4578:26;:24;:26::i;:::-;4545:59;;4621:1;:20;;;;;;;;;;;;:71;;4690:1;4683:9;;4621:71;;;4644:36;;;4621:71;4614:78;;;4472:227;:::o;5842:159:131:-;5912:9;5907:88;5927:6;;:13;;5923:1;:17;5907:88;;;5961:23;5974:6;;5981:1;5974:9;;;;;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;5961:12;:23::i;:::-;5942:3;;;;;5907:88;;;;5842:159;;:::o;6660:3495::-;6814:37;6865:18;6897:19;6930:17;2608:6;;;;;;;;;;;2594:20;;:10;:20;;;2590:69;;2637:11;;;;;;;;;;;;;;2590:69;6972:15:::1;6997:44:::0;7044:6:::1;;7051:1;7044:9;;;;;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;:15;;;;;;;;:::i;:::-;:25;;;;;;;;;;:::i;:::-;6997:72;;7116:6;;:13;;7098:32;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;7079:51;;7145:9;7140:2923;7160:6;;:13;;7156:1;:17;7140:2923;;;7194:36;7233:6;;7240:1;7233:9;;;;;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;:15;;;;;;;;:::i;:::-;7194:54;;;:::i;:::-;;;7267:38;7299:5;7267:31;:38::i;:::-;7262:113;;7325:9;;;;:::i;:::-;;;7352:8;;;7262:113;7389:17;7409:16;7419:5;7409:9;:16::i;:::-;7389:36;;7439:11;1889:1:::0;7453:60:::1;;:14;:25;7468:9;7453:25;;;;;;;;;;;:35;;;;;;;;;;;;:60;;;;7439:74;;7527:28;7811:6;7807:860;;;7837:11;1938:1;7851:52;;:14;:25;7866:9;7851:25;;;;;;;;;;;:35;;;;;;;;;;;;:52;;;7837:66;;7925:6;7921:92;;;7955:9;;;;:::i;:::-;;;7986:8;;;;;;;7921:92;8134:14;:25;8149:9;8134:25;;;;;;;;;;;:35;;;;;;;;;;;;8111:58;;;;8243:1;8219:25;;;;7819:458;7807:860;;;8353:19;8375:38;8392:6;;8399:1;8392:9;;;;;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;8375:38;;;:::i;:::-;8403:9;8375:16;:38::i;:::-;8353:60;;8436:14;8431:101;;8474:9;;;;:::i;:::-;;;8505:8;;;;;;;8431:101;8634:5;:18;;;8611:41;;8283:384;7807:860;8737:17;8757:54;8766:20;8788:6;;8795:1;8788:9;;;;;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;:22;;;8757:8;:54::i;:::-;8737:74;;8899:9;8876:20;:32;8853:55;;8954:260;;;;;;;;8999:44;9041:1;9018:20;:24;8999:18;:44::i;:::-;8954:260;;;;;;9079:116;9164:9;9123:14;:25;9138:9;9123:25;;;;;;;;;;;:38;;;;;;;;;;;;:50;;;9079:18;:116::i;:::-;8954:260;;;;::::0;8926:14:::1;:25;8941:9;8926:25;;;;;;;;;;;:288;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;9243:34;;:::i;:::-;9342:86;9382:5;9405:9;9342:22;:86::i;:::-;9292:13;:26;;9320:13;:18;;9291:137;;;::::0;::::1;;;::::0;::::1;;9496:6;;9503:1;9496:9;;;;;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;:19;;;9475:13;:18;;;9446:13;:26;;;:47;;;;:::i;:::-;:69;9442:134;;;9542:19;;;;;;;;;;;;;;9442:134;9634:13;:18;;;9605:13;:26;;;:47;;;;:::i;:::-;9590:62;;;;;:::i;:::-;;;9679:13;:18;;;9666:31;;;;;:::i;:::-;;;9733:50;;;;;;;;9745:13;:26;;;9733:50;;;;9773:9;9733:50;;::::0;9711:16:::1;9728:1;9711:19;;;;;;;;:::i;:::-;;;;;;;:72;;;;9802:63;9821:6;;9828:1;9821:9;;;;;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;:15;;;;;;;;:::i;:::-;:18;;;;;;;;;;:::i;:::-;9841:16;9859:5;9802:18;:63::i;:::-;9797:134;;9892:24;;;;;;;;;;;;;;9797:134;9970:3;9948:26;;:10;:26;;::::0;9944:109:::1;;10007:31;10022:6;;10029:1;10022:9;;;;;;;:::i;:::-;;;;;;;;;;;;;:::i;:::-;:15;;;;;;;;:::i;:::-;10007:31;;;:::i;:::-;:14;:31::i;:::-;9994:44;;9944:109;7180:2883;;;;;;7140:2923;7175:3;;;;;7140:2923;;;;10088:6;;:13;;10077:7;:24:::0;10073:76:::1;;10124:14;;;;;;;;;;;;;;10073:76;6962:3193;;6660:3495:::0;;;;;;;:::o;3864:164:57:-;3914:7;3933:30;3966:26;:24;:26::i;:::-;3933:59;;4009:1;:12;;;;;;;;;;;;4002:19;;;3864:164;:::o;3082:318:131:-;4158:30:58;4191:26;:24;:26::i;:::-;4158:59;;4279:19;4302:1;:15;;;;;;;;;;;;4301:16;4279:38;;4327:18;4348:1;:14;;;;;;;;;;;;4327:35;;4704:17;4739:1;4724:11;:16;;;:34;;;;;4744:14;4724:34;4704:54;;4768:17;4803:1;4788:11;:16;;;:50;;;;;4837:1;4816:4;4808:25;;;:30;4788:50;4768:70;;4854:12;4853:13;:30;;;;;4871:12;4870:13;4853:30;4849:91;;;4906:23;;;;;;;;;;;;;;4849:91;4966:1;4949;:14;;;:18;;;;;;;;;;;;;;;;;;4981:14;4977:67;;;5029:4;5011:1;:15;;;:22;;;;;;;;;;;;;;;;;;4977:67;3230:39:131::1;3251:17;3230:20;:39::i;:::-;3279:50;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;;;;;::::0;:13:::1;:50::i;:::-;3354:13;3339:12;;:28;;;;;;;;;;;;;;;;;;3386:7;3377:6;;:16;;;;;;;;;;;;;;;;;;5068:14:58::0;5064:101;;;5116:5;5098:1;:15;;;:23;;;;;;;;;;;;;;;;;;5140:14;5152:1;5140:14;;;;;;:::i;:::-;;;;;;;;5064:101;4092:1079;;;;;3082:318:131;;;:::o;3534:132::-;3766:39:57;3780:12;:10;:12::i;:::-;3794:10;:8;:10::i;:::-;3766:13;:39::i;:::-;3611:9:131::1;3602:6;;:18;;;;;;;;;;;;;;;;;;3649:9;3635:24;;;;;;;;;;;;3534:132:::0;:::o;351:66:132:-;395:15;408:1;395:12;:15::i;:::-;351:66::o;845:147::-;929:4;975:10;952:5;:19;958:12;952:19;;;;;;;;;;;;;;;;:33;945:40;;845:147;;;;:::o;3672:168:131:-;3766:39:57;3780:12;:10;:12::i;:::-;3794:10;:8;:10::i;:::-;3766:13;:39::i;:::-;3767:15:131::1;3752:12;;:30;;;;;;;;;;;;;;;;;;3817:15;3797:36;;;;;;;;;;;;3672:168:::0;:::o;2344:21::-;;;;;;;;;;;;;:::o;19789:636::-;19874:18;19904;19941:5;:8;;;19904:46;;19983:38;19964:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;19960:459;;20049:2;:9;;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;20036:24;;19960:459;;;20100:38;20081:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;20077:342;;20166:5;:8;;;20153:21;;20077:342;;;20214:38;20195:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;20191:228;;20281:2;:9;;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;20268:24;;20191:228;;;20332:38;20313:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;20309:110;;20398:2;:8;;;:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;20385:23;;20309:110;20191:228;20077:342;19960:459;19894:531;19789:636;;;:::o;11570:790::-;11714:1;11697:6;:13;:18;11693:55;11731:7;11693:55;11848:13;11875:15;11904:13;11931:16;11961:7;11982:9;12005;12038:6;12027:81;;;;;;;;;;;;:::i;:::-;11834:274;;;;;;;;;;;;;;12198:11;12185:32;;;12231:5;12250:7;12271:5;12290:8;12312:1;12327;12342;12185:168;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;11643:717;;;;;;;11570:790;;;:::o;887:96:62:-;940:7;966:10;959:17;;887:96;:::o;989:99::-;1040:14;;1073:8;;1066:15;;;;989:99;;:::o;5282:667:57:-;5369:30;5402:26;:24;:26::i;:::-;5369:59;;5439:14;5455:12;5471:144;5516:11;:9;:11::i;:::-;5541:6;5569:4;5595;;5600:1;5595:9;5602:1;5595:9;;;;;;;:::i;:::-;5588:17;;;;;:::i;:::-;5471:31;:144::i;:::-;5438:177;;;;5630:9;5625:318;;5667:1;5659:5;:9;;;5655:278;;;5711:4;5688:1;:20;;;:27;;;;;;;;;;;;;;;;;;5748:11;:9;:11::i;:::-;5733:46;;;5780:6;5788:4;;5733:60;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5834:5;5811:1;:20;;;:28;;;;;;;;;;;;;;;;;;5655:278;;;5911:6;5885:33;;;;;;;;;;;:::i;:::-;;;;;;;;5655:278;5625:318;5359:590;;;5282:667;;;:::o;3478:178:64:-;2226:16;:14;:16::i;:::-;3536:25:::1;3564:21;:19;:21::i;:::-;3536:49;;3607:5;3595:1;:9;;;:17;;;;;;;;;;;;;;;;;;3627:22;3636:12;:10;:12::i;:::-;3627:22;;;;;;:::i;:::-;;;;;;;;3526:130;3478:178::o:0;4837:176:66:-;4914:7;4940:66;4973:20;:18;:20::i;:::-;4995:10;4940:32;:66::i;:::-;4933:73;;4837:176;;;:::o;1147:162:64:-;1200:25;1270:23;1260:33;;1147:162;:::o;4887:220:57:-;4959:30;4992:26;:24;:26::i;:::-;4959:59;;5043:12;5028:1;:12;;;:27;;;;;;;;;;;;;;;;;;5070:30;5087:12;5070:30;;;;;;:::i;:::-;;;;;;;;4949:158;4887:220;:::o;3170:176:64:-;1979:19;:17;:19::i;:::-;3229:25:::1;3257:21;:19;:21::i;:::-;3229:49;;3300:4;3288:1;:9;;;:16;;;;;;;;;;;;;;;;;;3319:20;3326:12;:10;:12::i;:::-;3319:20;;;;;;:::i;:::-;;;;;;;;3219:127;3170:176::o:0;2611:156:66:-;2662:23;2730:21;2720:31;;2611:156;:::o;6175:155::-;6229:13;6254:23;6280:19;:17;:19::i;:::-;6254:45;;6316:1;:7;;6309:14;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;6175:155;:::o;6557:161::-;6614:13;6639:23;6665:19;:17;:19::i;:::-;6639:45;;6701:1;:10;;6694:17;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;6557:161;:::o;1605:177:57:-;1663:30;1738:28;1728:38;;1605:177;:::o;15084:656:131:-;15168:4;15295:15;15279:5;:12;;;:31;15275:74;;15333:5;15326:12;;;;15275:74;15476:15;15452:5;:8;;;15436:34;;;:36;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:55;15432:98;;15514:5;15507:12;;;;15432:98;15595:37;15607:5;:11;;;15620:5;:11;;;15595;:37::i;:::-;15590:81;;15655:5;15648:12;;;;15590:81;15729:4;15722:11;;15084:656;;;;:::o;12366:648::-;12504:12;12573:13;12589:5;:11;;;:17;;;12573:33;;12616:12;12681:5;12669:18;12661:26;;12718:1;12710:4;:9;12706:302;;12745:71;12782:5;12789:9;12800:5;:15;;;12745:36;:71::i;:::-;12735:81;;12706:302;;;12857:140;12918:5;12941:9;12968:5;:15;;;12857:43;:140::i;:::-;12847:150;;12706:302;12518:496;;12366:648;;;;:::o;5617:111:50:-;5675:7;5701:20;5713:1;5709;:5;5716:1;5719;5701:7;:20::i;:::-;5694:27;;5617:111;;;;:::o;9264:218:51:-;9321:7;9352:17;9344:25;;:5;:25;9340:105;;;9423:3;9428:5;9392:42;;;;;;;;;;;;:::i;:::-;;;;;;;;9340:105;9469:5;9454:21;;9264:218;;;:::o;16374:2694:131:-;16490:20;16512:12;16537:37;16577:5;:15;;;16537:55;;16666:27;16696:206;1987:2;16696:183;16733:5;:17;;;16803:15;16780:5;:8;;;16764:34;;;:36;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:54;;;;:::i;:::-;16848:5;:8;;;16832:35;;;:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;16696:23;:183::i;:::-;:191;;:206;;;;:::i;:::-;16666:236;;16976:22;17001:61;1987:2;17017:5;:8;;;17001:36;;;:38;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:46;;:61;;;;:::i;:::-;16976:86;;17073:11;17087:14;17095:5;17087:7;:14::i;:::-;17073:28;;17152:1;17146:7;;17180:38;17167:51;;;;;;;;:::i;:::-;;:9;:51;;;;;;;;:::i;:::-;;;17163:1899;;17336:20;17390:14;1987:2;2028;:19;;;;:::i;:::-;17360;:26;;;;:::i;:::-;17359:45;;;;:::i;:::-;17336:68;;1987:2;2028;:19;;;;:::i;:::-;17446:12;17434:9;:24;;;;:::i;:::-;17433:33;;;;:::i;:::-;17418:48;;17503:1;17496:3;:8;17493:82;;17557:3;1987:2;2028;:19;;;;:::i;:::-;17543:3;:10;;;;:::i;:::-;17530:9;:24;;;;:::i;:::-;:30;;;;:::i;:::-;17523:37;;17493:82;17220:365;17163:1899;;;17608:38;17595:51;;;;;;;;:::i;:::-;;:9;:51;;;;;;;;:::i;:::-;;;17591:1471;;17709:20;17758:19;1987:2;2028;:19;;;;:::i;:::-;17733:14;:21;;;;:::i;:::-;17732:45;;;;:::i;:::-;17709:68;;1987:2;2028;:19;;;;:::i;:::-;17819:12;17807:9;:24;;;;:::i;:::-;17806:33;;;;:::i;:::-;17791:48;;17863:1;17856:3;:8;17853:86;;1987:2;2028;:19;;;;:::i;:::-;1987:2;2028;:19;;;;:::i;:::-;17906:3;:10;;;;:::i;:::-;17890:12;:27;;;;:::i;:::-;:34;;;;:::i;:::-;17883:41;;17853:86;17648:301;17591:1471;;;17972:38;17959:51;;;;;;;;:::i;:::-;;:9;:51;;;;;;;;:::i;:::-;;;17955:1107;;18099:27;18197:19;18129:49;18175:2;18145:5;:8;;;18129:35;;;:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:45;;:49;;;;:::i;:::-;:87;;;;:::i;:::-;18099:117;;18230:20;18284:14;1987:2;2028;:19;;;;:::i;:::-;18254;:26;;;;:::i;:::-;18253:45;;;;:::i;:::-;18230:68;;1987:2;2028;:19;;;;:::i;:::-;18340:12;18328:9;:24;;;;:::i;:::-;18327:33;;;;:::i;:::-;18312:48;;18384:1;18377:3;:8;18374:99;;18439:19;1987:2;2028;:19;;;;:::i;:::-;18424:3;:10;;;;:::i;:::-;18411:9;:24;;;;:::i;:::-;:47;;;;:::i;:::-;18404:54;;18374:99;18012:471;;17955:1107;;;18506:38;18493:51;;;;;;;;:::i;:::-;;:9;:51;;;;;;;;:::i;:::-;;;18489:573;;18607:27;18705:19;18637:49;18683:2;18653:5;:8;;;18637:35;;;:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:45;;:49;;;;:::i;:::-;:87;;;;:::i;:::-;18607:117;;18738:20;18787:19;1987:2;2028;:19;;;;:::i;:::-;18762:14;:21;;;;:::i;:::-;18761:45;;;;:::i;:::-;18738:68;;1987:2;2028;:19;;;;:::i;:::-;18848:12;18836:9;:24;;;;:::i;:::-;18835:33;;;;:::i;:::-;18820:48;;18892:1;18885:3;:8;18882:114;;18962:19;1987:2;2028;:19;;;;:::i;:::-;18949:3;1987:2;2028;:19;;;;:::i;:::-;18935:3;:10;;;;:::i;:::-;18919:12;:27;;;;:::i;:::-;:33;;;;:::i;:::-;:40;;;;:::i;:::-;:62;;;;:::i;:::-;18912:69;;18882:114;18546:460;;18489:573;;;19033:18;;;;;;;;;;;;;;18489:573;17955:1107;17591:1471;17163:1899;16526:2542;;;;16374:2694;;;;;:::o;13020:1161::-;13211:12;13289:16;13277:28;;:5;:8;;;:28;;;13273:71;;13328:5;13321:12;;;;13273:71;13390:38;13370:58;;;;;;;;:::i;:::-;;:16;:58;;;;;;;;:::i;:::-;;;:132;;;;13464:38;13444:58;;;;;;;;:::i;:::-;;:16;:58;;;;;;;;:::i;:::-;;;13370:132;13353:800;;;13567:38;13548:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;:134;;;;13644:38;13625:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;13548:134;13527:214;;;13722:4;13715:11;;;;13527:214;13353:800;;;13794:38;13774:58;;;;;;;;:::i;:::-;;:16;:58;;;;;;;;:::i;:::-;;;:131;;;;;13867:38;13848:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;13774:131;13757:396;;;13937:4;13930:11;;;;13757:396;13995:38;13975:58;;;;;;;;:::i;:::-;;:16;:58;;;;;;;;:::i;:::-;;;:131;;;;;14068:38;14049:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;13975:131;13958:195;;;14138:4;14131:11;;;;13958:195;13353:800;14169:5;14162:12;;13020:1161;;;;;;:::o;19074:709::-;19173:18;19203;19240:5;:8;;;19203:46;;19282:38;19263:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;19259:518;;19349:5;:8;;;19336:21;;19259:518;;;19397:38;19378:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;19374:403;;19464:2;:9;;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;19451:24;;19374:403;;;19515:38;19496:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;19492:285;;19582:2;:8;;;:10;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;19569:23;;19492:285;;;19632:38;19613:57;;;;;;;;:::i;:::-;;:5;:15;;;:57;;;;;;;;:::i;:::-;;;19609:168;;19699:2;:9;;;:11;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;19686:24;;19609:168;;;19748:18;;;;;;;;;;;;;;19609:168;19492:285;19374:403;19259:518;19193:590;19074:709;;;:::o;9071:205:58:-;9129:30;9171:12;9186:27;:25;:27::i;:::-;9171:42;;9256:4;9246:14;;9232:38;9071:205;:::o;1876:147:57:-;6929:20:58;:18;:20::i;:::-;1968:48:57::1;1999:16;1968:30;:48::i;:::-;1876:147:::0;:::o;3337::66:-;6929:20:58;:18;:20::i;:::-;3439:38:66::1;3463:4;3469:7;3439:23;:38::i;:::-;3337:147:::0;;:::o;591:782:3:-;746:14;762:12;786:17;842:6;850;858:8;806:62;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;786:82;;931:4;925;918:18;962:4;956;949:18;1049:4;1043;1036;1030:11;1023:4;1017;1013:15;1002:9;995:5;984:70;981:376;;;1092:4;1086:11;1073:24;;1129:4;1123:11;1114:20;;1335:5;1331:2;1327:14;1320:22;1313:5;1309:34;1300:43;;981:376;904:463;591:782;;;;;;;:::o;2909:126:64:-;2972:8;:6;:8::i;:::-;2967:62;;3003:15;;;;;;;;;;;;;;2967:62;2909:126::o;3906:109:66:-;3959:7;3985:23;:21;:23::i;:::-;3978:30;;3906:109;:::o;3874:374:47:-;3967:14;4049:4;4043:11;4079:10;4074:3;4067:23;4126:15;4119:4;4114:3;4110:14;4103:39;4178:10;4171:4;4166:3;4162:14;4155:34;4227:4;4222:3;4212:20;4202:30;;4018:224;3874:374;;;;:::o;2709:128:64:-;2774:8;:6;:8::i;:::-;2770:61;;;2805:15;;;;;;;;;;;;;;2770:61;2709:128::o;1499:429:48:-;1605:4;1647:1;1625:6;:18;;;:23;1621:301;;1665:17;1684:22;1712:33;1729:4;1735:9;1712:16;:33::i;:::-;1664:81;;;;;1773:26;1766:33;;;;;;;;:::i;:::-;;:3;:33;;;;;;;;:::i;:::-;;;:56;;;;;1816:6;1803:19;;:9;:19;;;1766:56;1759:63;;;;;;1621:301;1860:51;1887:6;1895:4;1901:9;1860:26;:51::i;:::-;1853:58;;1499:429;;;;;;:::o;2335:458::-;2478:4;2495:12;2509:19;2532:6;:17;;2606:4;2612:9;2563:60;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2532:101;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;2494:139;;;;2651:7;:42;;;;;2691:2;2674:6;:13;:19;;2651:42;:134;;;;;2750:34;;;2742:43;;;2720:6;2709:29;;;;;;;;;;;;:::i;:::-;:76;2651:134;2643:143;;;;2335:458;;;;;:::o;5071:294:50:-;5149:7;5321:26;5337:9;5321:15;:26::i;:::-;5316:1;5312;:5;5311:36;5306:1;:42;5299:49;;5071:294;;;;;:::o;14187:620:131:-;14341:7;14404:8;1825;1987:2;2028;:19;;;;:::i;:::-;14422:8;:15;;;;:::i;:::-;14415:42;;;;:::i;:::-;14404:53;;14467:14;1987:2;2028;:19;;;;:::i;:::-;14467:29;;14506:11;14537:17;14520:7;:35;;;;:::i;:::-;14506:49;;14565:20;14588:19;14602:4;14588:13;:19::i;:::-;14565:42;;14617:18;14638:45;14675:7;14670:1;14654:13;:17;;;;:::i;:::-;14653:29;;;;:::i;:::-;14638:14;:45::i;:::-;14617:66;;14693:19;14751:11;14740:7;14723:13;14716:31;;;;:::i;:::-;14715:47;;;;:::i;:::-;14693:69;;14787:12;14772:28;;;;;;;;14187:620;;;;;:::o;788:226:92:-;859:9;880:22;927:9;377:2;912:24;;;;:::i;:::-;905:2;:32;;;;:::i;:::-;880:57;;983:14;979:2;975:23;970:28;;956:52;788:226;;;;:::o;20431:356:131:-;20492:12;20516:16;20551:6;;;;;;;;;;;20535:35;;;:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;20516:56;;20582:15;20610:8;20600:36;;;:38;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;20582:56;;20648:20;20711:15;20687:6;:9;;;20671:35;;;:37;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;:55;;;;:::i;:::-;20648:78;;20743:37;20758:7;20767:12;20743:14;:37::i;:::-;20736:44;;20506:281;;;20431:356;;;:::o;8819:122:58:-;8887:7;3147:66;8913:21;;8906:28;;8819:122;:::o;7082:141::-;7149:17;:15;:17::i;:::-;7144:73;;7189:17;;;;;;;;;;;;;;7144:73;7082:141::o;2029:140:57:-;6929:20:58;:18;:20::i;:::-;2131:31:57::1;2145:16;2131:13;:31::i;:::-;2029:140:::0;:::o;3490:330:66:-;6929:20:58;:18;:20::i;:::-;3602:23:66::1;3628:19;:17;:19::i;:::-;3602:45;;3667:4;3657:1;:7;;:14;;;;;;:::i;:::-;;3694:7;3681:1;:10;;:20;;;;;;:::i;:::-;;3782:1;3766:17:::0;::::1;:1;:13;;:17;;;;3812:1;3793:20:::0;::::1;:1;:16;;:20;;;;3592:228;3490:330:::0;;:::o;4021:191::-;4076:7;1964:95;4134:17;:15;:17::i;:::-;4153:20;:18;:20::i;:::-;4175:13;4198:4;4112:92;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;4102:103;;;;;;4095:110;;4021:191;:::o;2129:778:45:-;2232:17;2251:16;2269:14;2319:2;2299:9;:16;:22;2295:606;;2337:9;2360;2383:7;2604:4;2593:9;2589:20;2583:27;2578:32;;2653:4;2642:9;2638:20;2632:27;2627:32;;2710:4;2699:9;2695:20;2689:27;2686:1;2681:36;2676:41;;2751:25;2762:4;2768:1;2771;2774;2751:10;:25::i;:::-;2744:32;;;;;;;;;;;2295:606;2823:1;2827:35;2872:9;:16;2864:25;;2807:83;;;;;;2129:778;;;;;;:::o;34795:145:51:-;34842:9;34921:1;34914:9;34907:17;34902:22;;34795:145;;;:::o;10764:397:89:-;10809:6;10950:1;10946;:5;10938:31;;;;;;;;;;;;:::i;:::-;;;;;;;;;11007:1;2945:4;1907;2936:13;10987:21;:46;;;;;3000:4;1907;2991:13;11012:1;:21;10987:46;10983:162;;;1907:4;11060:9;11067:1;11060:6;:9::i;:::-;:18;;;;;:::i;:::-;;;11053:25;;;;10983:162;11124:6;11128:1;11124:3;:6::i;:::-;11117:13;;10764:397;;;;:::o;4828:5831::-;4874:6;2743;4924:1;:25;;:54;;;;;2692:6;4953:1;:25;;4924:54;4916:83;;;;;;;;;;;;:::i;:::-;;;;;;;;;5022:1;5018;:5;5014:373;;;5364:7;5369:1;5368:2;;5364:3;:7::i;:::-;1907:4;;5345:15;5344:27;;;;;:::i;:::-;;;5336:36;;;;5014:373;6748:14;3132:21;6780:1;:7;6776:252;;3132:21;6807:7;;;;3188:56;6832:12;;6776:252;;;3296:20;6869:1;:7;6865:163;;3296:20;6896:7;;;;3351:28;6921:12;;6865:163;;;6982:1;6972:11;;6865:163;6776:252;7195:3;7190:8;;;;7423:14;2097:4;7423:23;;3460:22;7465:1;:7;7461:104;;3460:22;7492:7;;;;2097:4;3517:34;7528:7;:12;7527:23;;;;;:::i;:::-;;;7517:33;;7461:104;3589:22;7582:1;:7;7578:104;;3589:22;7609:7;;;;2097:4;3646:27;7645:7;:12;7644:23;;;;;:::i;:::-;;;7634:33;;7578:104;3711:21;7699:1;:7;7695:104;;3711:21;7726:7;;;;2097:4;3767:24;7762:7;:12;7761:23;;;;;:::i;:::-;;;7751:33;;7695:104;3829:21;7816:1;:7;7812:104;;3829:21;7843:7;;;;2097:4;3885:22;7879:7;:12;7878:23;;;;;:::i;:::-;;;7868:33;;7812:104;3945:21;7933:1;:7;7929:104;;3945:21;7960:7;;;;2097:4;4001:21;7996:7;:12;7995:23;;;;;:::i;:::-;;;7985:33;;7929:104;4060:21;8050:1;:7;8046:104;;4060:21;8077:7;;;;2097:4;4116:21;8113:7;:12;8112:23;;;;;:::i;:::-;;;8102:33;;8046:104;4175:20;8167:1;:7;8163:104;;4175:20;8194:7;;;;2097:4;4231:21;8230:7;:12;8229:23;;;;;:::i;:::-;;;8219:33;;8163:104;4290:20;8284:1;:7;8280:104;;4290:20;8311:7;;;;2097:4;4346:21;8347:7;:12;8346:23;;;;;:::i;:::-;;;8336:33;;8280:104;8704:16;2097:4;8704:25;;8798:11;8933:1;8926:8;;8961:4;8948:17;;;;9245:1;2097:4;9230:1;9223:4;:8;9222:19;;;;;:::i;:::-;;;9221:25;;;;;:::i;:::-;;;9214:32;;9273:4;9260:17;;;;9323:1;2097:4;9308:1;9301:4;:8;9300:19;;;;;:::i;:::-;;;9299:25;;;;;:::i;:::-;;;9292:32;;9351:4;9338:17;;;;9401:1;2097:4;9386:1;9379:4;:8;9378:19;;;;;:::i;:::-;;;9377:25;;;;;:::i;:::-;;;9370:32;;9429:4;9416:17;;;;9479:1;2097:4;9464:1;9457:4;:8;9456:19;;;;;:::i;:::-;;;9455:25;;;;;:::i;:::-;;;9448:32;;9507:4;9494:17;;;;9557:1;2097:4;9542:1;9535:4;:8;9534:19;;;;;:::i;:::-;;;9533:25;;;;;:::i;:::-;;;9526:32;;9585:4;9572:17;;;;9635:1;2097:4;9620:1;9613:4;:8;9612:19;;;;;:::i;:::-;;;9611:25;;;;;:::i;:::-;;;9604:32;;9663:4;9650:17;;;;9713:1;2097:4;9698:1;9691:4;:8;9690:19;;;;;:::i;:::-;;;9689:25;;;;;:::i;:::-;;;9682:32;;9741:4;9728:17;;;;9791:1;2097:4;9776:1;9769:4;:8;9768:19;;;;;:::i;:::-;;;9767:25;;;;;:::i;:::-;;;9760:32;;9819:4;9806:17;;;;9869:2;2097:4;9854:1;9847:4;:8;9846:19;;;;;:::i;:::-;;;9845:26;;;;;:::i;:::-;;;9838:33;;9898:4;9885:17;;;;9948:2;2097:4;9933:1;9926:4;:8;9925:19;;;;;:::i;:::-;;;9924:26;;;;;:::i;:::-;;;9917:33;;9977:4;9964:17;;;;10027:2;2097:4;10012:1;10005:4;:8;10004:19;;;;;:::i;:::-;;;10003:26;;;;;:::i;:::-;;;9996:33;;10056:4;10043:17;;;;10639:3;10628:7;2097:4;10605:9;10595:7;:19;10594:30;;;;;:::i;:::-;;;10593:42;10592:50;;;;;:::i;:::-;;;10585:57;;;;;;4828:5831;;;;:::o;11386:2411::-;11444:7;11496:1;11491;:6;11487:143;;1907:4;11593:22;;;;11487:143;11653:1;11648;:6;11644:53;;11681:1;11674:8;;;;11644:53;12100:8;12096:1;:12;12088:40;;;;;;;;;;;;:::i;:::-;;;;;;;;;12142:15;12167:1;12142:27;;2097:4;3050:8;:26;;;;;:::i;:::-;;;12547:1;:23;12539:51;;;;;;;;;;;;:::i;:::-;;;;;;;;;12604:15;12629:1;12604:27;;12646:19;12703:8;2945:4;1907;2936:13;12683:28;:60;;;;;3000:4;1907;2991:13;12715:8;:28;12683:60;12679:780;;;12763:14;12780:16;12787:8;12780:6;:16::i;:::-;12763:33;;1907:4;13327:8;1907:4;13307:7;:16;;;;;:::i;:::-;;;13306:29;13305:60;;;;;:::i;:::-;;;13274:8;1907:4;13234:7;:16;;;;;:::i;:::-;;;13233:49;:132;13217:149;;12745:636;12679:780;;;13436:8;13420:13;13424:8;13420:3;:13::i;:::-;:24;13405:39;;12679:780;1907:4;13472:22;;;;;;:::i;:::-;;;;;13625:12;2743:6;13601:36;;:76;;;;;2692:6;13641:12;:36;;13601:76;13576:156;;;;;;;;;;;;:::i;:::-;;;;;;;;;13762:17;13766:12;13762:3;:17::i;:::-;13747:33;;;;;11386:2411;;;;;:::o;8485:120:58:-;8535:4;8558:26;:24;:26::i;:::-;:40;;;;;;;;;;;;8551:47;;8485:120;:::o;6933:687:66:-;6983:7;7002:23;7028:19;:17;:19::i;:::-;7002:45;;7057:18;7078:13;:11;:13::i;:::-;7057:34;;7126:1;7111:4;7105:18;:22;7101:513;;;7166:4;7150:22;;;;;;7143:29;;;;;;7101:513;7426:18;7447:1;:13;;;7426:34;;7492:1;7478:15;;:10;:15;7474:130;;7520:10;7513:17;;;;;;;7474:130;7576:13;7569:20;;;;;6933:687;;:::o;7841:723::-;7894:7;7913:23;7939:19;:17;:19::i;:::-;7913:45;;7968:21;7992:16;:14;:16::i;:::-;7968:40;;8046:1;8028:7;8022:21;:25;8018:540;;;8086:7;8070:25;;;;;;8063:32;;;;;;8018:540;8358:21;8382:1;:16;;;8358:40;;8433:1;8416:18;;:13;:18;8412:136;;8461:13;8454:20;;;;;;;8412:136;8520:13;8513:20;;;;;7841:723;;:::o;5203:1551:45:-;5329:17;5348:16;5366:14;6283:66;6278:1;6270:10;;:79;6266:164;;;6381:1;6385:30;6417:1;6365:54;;;;;;;;6266:164;6524:14;6541:24;6551:4;6557:1;6560;6563;6541:24;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;6524:41;;6597:1;6579:20;;:6;:20;;;6575:113;;6631:1;6635:29;6674:1;6666:10;;6615:62;;;;;;;;;6575:113;6706:6;6714:20;6744:1;6736:10;;6698:49;;;;;;;5203:1551;;;;;;;;;:::o;19574:1872:89:-;19622:6;1907:4;19880:11;;;;20272:8;2132:4;20310:1;:10;2132:4;;20285:1;:10;20284:21;20283:38;;;;;:::i;:::-;;;20272:49;;20335:16;2132:4;20359:1;20355;:5;20354:16;;;;;:::i;:::-;;;20335:35;;20459:10;20472:1;20459:14;;20595:16;20614:3;20595:22;;2132:4;20709:9;20703:3;:15;20702:26;;;;;:::i;:::-;;;20696:32;;20761:1;20755:3;:7;;;;;:::i;:::-;;;20742:20;;;;2132:4;20790:9;20784:3;:15;20783:26;;;;;:::i;:::-;;;20777:32;;20842:1;20836:3;:7;;;;;:::i;:::-;;;20823:20;;;;2132:4;20871:9;20865:3;:15;20864:26;;;;;:::i;:::-;;;20858:32;;20923:1;20917:3;:7;;;;;:::i;:::-;;;20904:20;;;;2132:4;20952:9;20946:3;:15;20945:26;;;;;:::i;:::-;;;20939:32;;21004:1;20998:3;:7;;;;;:::i;:::-;;;20985:20;;;;2132:4;21033:9;21027:3;:15;21026:26;;;;;:::i;:::-;;;21020:32;;21085:2;21079:3;:8;;;;;:::i;:::-;;;21066:21;;;;2132:4;21115:9;21109:3;:15;21108:26;;;;;:::i;:::-;;;21102:32;;21167:2;21161:3;:8;;;;;:::i;:::-;;;21148:21;;;;2132:4;21197:9;21191:3;:15;21190:26;;;;;:::i;:::-;;;21184:32;;21249:2;21243:3;:8;;;;;:::i;:::-;;;21230:21;;;;21428:1;21416:9;:13;21409:20;;;;;;19574:1872;;;:::o;13911:5397::-;13956:6;1907:4;14002:1;:10;13998:402;;;14358:26;14382:1;1907:4;;14363:15;14362:21;;;;;:::i;:::-;;;14358:3;:26::i;:::-;14357:27;;14349:36;;;;13998:402;15781:10;1907:4;3188:56;15818:11;15813:1;:16;15809:126;;3188:56;15849:7;;;;;;:::i;:::-;;;;;3132:21;15911:9;;;;15809:126;1907:4;3351:28;15958:11;15953:1;:16;15949:126;;3351:28;15989:7;;;;;;:::i;:::-;;;;;3296:20;16051:9;;;;15949:126;16221:3;16214:10;;;;16243:3;16238:8;;;;3517:34;16381:1;:7;16377:94;;3517:34;2097:4;16413:1;:10;16412:17;;;;;:::i;:::-;;;16408:21;;3460:22;16447:9;;;;16377:94;3646:27;16489:1;:7;16485:94;;3646:27;2097:4;16521:1;:10;16520:17;;;;;:::i;:::-;;;16516:21;;3589:22;16555:9;;;;16485:94;3767:24;16597:1;:7;16593:94;;3767:24;2097:4;16629:1;:10;16628:17;;;;;:::i;:::-;;;16624:21;;3711;16663:9;;;;16593:94;3885:22;16705:1;:7;16701:94;;3885:22;2097:4;16737:1;:10;16736:17;;;;;:::i;:::-;;;16732:21;;3829;16771:9;;;;16701:94;4001:21;16813:1;:7;16809:94;;4001:21;2097:4;16845:1;:10;16844:17;;;;;:::i;:::-;;;16840:21;;3945;16879:9;;;;16809:94;4116:21;16921:1;:7;16917:94;;4116:21;2097:4;16953:1;:10;16952:17;;;;;:::i;:::-;;;16948:21;;4060;16987:9;;;;16917:94;4231:21;17029:1;:7;17025:94;;4231:21;2097:4;17061:1;:10;17060:17;;;;;:::i;:::-;;;17056:21;;4175:20;17095:9;;;;17025:94;4346:21;17137:1;:7;17133:94;;4346:21;2097:4;17169:1;:10;17168:17;;;;;:::i;:::-;;;17164:21;;4290:20;17203:9;;;;17133:94;4463:21;17245:1;:8;17241:97;;4463:21;2097:4;17278:1;:10;17277:18;;;;;:::i;:::-;;;17273:22;;4406:20;17313:10;;;;17241:97;4580:21;17356:1;:8;17352:97;;4580:21;2097:4;17389:1;:10;17388:18;;;;;:::i;:::-;;;17384:22;;4524:19;17424:10;;;;17352:97;17979:8;2097:4;18017:1;:10;2097:4;;17992:1;:10;17991:21;17990:38;;;;;:::i;:::-;;;17979:49;;18042:16;2097:4;18066:1;18062;:5;18061:16;;;;;:::i;:::-;;;18042:35;;18166:10;18179:1;18166:14;;18302:16;18321:3;18302:22;;2097:4;18416:9;18410:3;:15;18409:26;;;;;:::i;:::-;;;18403:32;;18468:1;18462:3;:7;;;;;:::i;:::-;;;18449:20;;;;2097:4;18497:9;18491:3;:15;18490:26;;;;;:::i;:::-;;;18484:32;;18549:1;18543:3;:7;;;;;:::i;:::-;;;18530:20;;;;2097:4;18578:9;18572:3;:15;18571:26;;;;;:::i;:::-;;;18565:32;;18630:1;18624:3;:7;;;;;:::i;:::-;;;18611:20;;;;2097:4;18659:9;18653:3;:15;18652:26;;;;;:::i;:::-;;;18646:32;;18711:1;18705:3;:7;;;;;:::i;:::-;;;18692:20;;;;2097:4;18740:9;18734:3;:15;18733:26;;;;;:::i;:::-;;;18727:32;;18792:2;18786:3;:8;;;;;:::i;:::-;;;18773:21;;;;18978:1;18965:14;;;;19288:3;19275:9;19269:3;:15;19268:23;;;;;:::i;:::-;;;19261:30;;;;;;;13911:5397;;;;:::o;-1:-1:-1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;;;;;;;;;;;;;:::o;:::-;;;;;;;;;;;;;;;;;;;:::o;7:75:140:-;40:6;73:2;67:9;57:19;;7:75;:::o;88:117::-;197:1;194;187:12;211:117;320:1;317;310:12;334:117;443:1;440;433:12;457:117;566:1;563;556:12;580:117;689:1;686;679:12;720:568;793:8;803:6;853:3;846:4;838:6;834:17;830:27;820:122;;861:79;;:::i;:::-;820:122;974:6;961:20;951:30;;1004:18;996:6;993:30;990:117;;;1026:79;;:::i;:::-;990:117;1140:4;1132:6;1128:17;1116:29;;1194:3;1186:4;1178:6;1174:17;1164:8;1160:32;1157:41;1154:128;;;1201:79;;:::i;:::-;1154:128;720:568;;;;;:::o;1294:559::-;1380:6;1388;1437:2;1425:9;1416:7;1412:23;1408:32;1405:119;;;1443:79;;:::i;:::-;1405:119;1591:1;1580:9;1576:17;1563:31;1621:18;1613:6;1610:30;1607:117;;;1643:79;;:::i;:::-;1607:117;1756:80;1828:7;1819:6;1808:9;1804:22;1756:80;:::i;:::-;1738:98;;;;1534:312;1294:559;;;;;:::o;1859:114::-;1926:6;1960:5;1954:12;1944:22;;1859:114;;;:::o;1979:184::-;2078:11;2112:6;2107:3;2100:19;2152:4;2147:3;2143:14;2128:29;;1979:184;;;;:::o;2169:132::-;2236:4;2259:3;2251:11;;2289:4;2284:3;2280:14;2272:22;;2169:132;;;:::o;2307:77::-;2344:7;2373:5;2362:16;;2307:77;;;:::o;2390:108::-;2467:24;2485:5;2467:24;:::i;:::-;2462:3;2455:37;2390:108;;:::o;2504:179::-;2573:10;2594:46;2636:3;2628:6;2594:46;:::i;:::-;2672:4;2667:3;2663:14;2649:28;;2504:179;;;;:::o;2689:113::-;2759:4;2791;2786:3;2782:14;2774:22;;2689:113;;;:::o;2838:732::-;2957:3;2986:54;3034:5;2986:54;:::i;:::-;3056:86;3135:6;3130:3;3056:86;:::i;:::-;3049:93;;3166:56;3216:5;3166:56;:::i;:::-;3245:7;3276:1;3261:284;3286:6;3283:1;3280:13;3261:284;;;3362:6;3356:13;3389:63;3448:3;3433:13;3389:63;:::i;:::-;3382:70;;3475:60;3528:6;3475:60;:::i;:::-;3465:70;;3321:224;3308:1;3305;3301:9;3296:14;;3261:284;;;3265:14;3561:3;3554:10;;2962:608;;;2838:732;;;;:::o;3576:634::-;3797:4;3835:2;3824:9;3820:18;3812:26;;3884:9;3878:4;3874:20;3870:1;3859:9;3855:17;3848:47;3912:108;4015:4;4006:6;3912:108;:::i;:::-;3904:116;;4067:9;4061:4;4057:20;4052:2;4041:9;4037:18;4030:48;4095:108;4198:4;4189:6;4095:108;:::i;:::-;4087:116;;3576:634;;;;;:::o;4216:126::-;4253:7;4293:42;4286:5;4282:54;4271:65;;4216:126;;;:::o;4348:96::-;4385:7;4414:24;4432:5;4414:24;:::i;:::-;4403:35;;4348:96;;;:::o;4450:122::-;4523:24;4541:5;4523:24;:::i;:::-;4516:5;4513:35;4503:63;;4562:1;4559;4552:12;4503:63;4450:122;:::o;4578:139::-;4624:5;4662:6;4649:20;4640:29;;4678:33;4705:5;4678:33;:::i;:::-;4578:139;;;;:::o;4723:102::-;4764:6;4815:2;4811:7;4806:2;4799:5;4795:14;4791:28;4781:38;;4723:102;;;:::o;4831:180::-;4879:77;4876:1;4869:88;4976:4;4973:1;4966:15;5000:4;4997:1;4990:15;5017:281;5100:27;5122:4;5100:27;:::i;:::-;5092:6;5088:40;5230:6;5218:10;5215:22;5194:18;5182:10;5179:34;5176:62;5173:88;;;5241:18;;:::i;:::-;5173:88;5281:10;5277:2;5270:22;5060:238;5017:281;;:::o;5304:129::-;5338:6;5365:20;;:::i;:::-;5355:30;;5394:33;5422:4;5414:6;5394:33;:::i;:::-;5304:129;;;:::o;5439:345::-;5550:4;5640:18;5632:6;5629:30;5626:56;;;5662:18;;:::i;:::-;5626:56;5712:4;5704:6;5700:17;5692:25;;5772:4;5766;5762:15;5754:23;;5439:345;;;:::o;5790:117::-;5899:1;5896;5889:12;5913:117;6022:1;6019;6012:12;6036:122;6109:24;6127:5;6109:24;:::i;:::-;6102:5;6099:35;6089:63;;6148:1;6145;6138:12;6089:63;6036:122;:::o;6164:139::-;6210:5;6248:6;6235:20;6226:29;;6264:33;6291:5;6264:33;:::i;:::-;6164:139;;;;:::o;6309:114::-;6397:1;6390:5;6387:12;6377:40;;6413:1;6410;6403:12;6377:40;6309:114;:::o;6429:169::-;6490:5;6528:6;6515:20;6506:29;;6544:48;6586:5;6544:48;:::i;:::-;6429:169;;;;:::o;6604:117::-;6713:1;6710;6703:12;6727:307;6788:4;6878:18;6870:6;6867:30;6864:56;;;6900:18;;:::i;:::-;6864:56;6938:29;6960:6;6938:29;:::i;:::-;6930:37;;7022:4;7016;7012:15;7004:23;;6727:307;;;:::o;7040:146::-;7137:6;7132:3;7127;7114:30;7178:1;7169:6;7164:3;7160:16;7153:27;7040:146;;;:::o;7192:423::-;7269:5;7294:65;7310:48;7351:6;7310:48;:::i;:::-;7294:65;:::i;:::-;7285:74;;7382:6;7375:5;7368:21;7420:4;7413:5;7409:16;7458:3;7449:6;7444:3;7440:16;7437:25;7434:112;;;7465:79;;:::i;:::-;7434:112;7555:54;7602:6;7597:3;7592;7555:54;:::i;:::-;7275:340;7192:423;;;;;:::o;7634:338::-;7689:5;7738:3;7731:4;7723:6;7719:17;7715:27;7705:122;;7746:79;;:::i;:::-;7705:122;7863:6;7850:20;7888:78;7962:3;7954:6;7947:4;7939:6;7935:17;7888:78;:::i;:::-;7879:87;;7695:277;7634:338;;;;:::o;8016:2087::-;8089:5;8133:6;8121:9;8116:3;8112:19;8108:32;8105:119;;;8143:79;;:::i;:::-;8105:119;8242:23;8258:6;8242:23;:::i;:::-;8233:32;;8324:1;8364:49;8409:3;8400:6;8389:9;8385:22;8364:49;:::i;:::-;8357:4;8350:5;8346:16;8339:75;8275:150;8486:2;8527:49;8572:3;8563:6;8552:9;8548:22;8527:49;:::i;:::-;8520:4;8513:5;8509:16;8502:75;8435:153;8648:2;8689:49;8734:3;8725:6;8714:9;8710:22;8689:49;:::i;:::-;8682:4;8675:5;8671:16;8664:75;8598:152;8814:2;8855:64;8915:3;8906:6;8895:9;8891:22;8855:64;:::i;:::-;8848:4;8841:5;8837:16;8830:90;8760:171;8988:3;9030:49;9075:3;9066:6;9055:9;9051:22;9030:49;:::i;:::-;9023:4;9016:5;9012:16;9005:75;8941:150;9151:3;9193:49;9238:3;9229:6;9218:9;9214:22;9193:49;:::i;:::-;9186:4;9179:5;9175:16;9168:75;9101:153;9317:3;9359:49;9404:3;9395:6;9384:9;9380:22;9359:49;:::i;:::-;9352:4;9345:5;9341:16;9334:75;9264:156;9487:3;9529:49;9574:3;9565:6;9554:9;9550:22;9529:49;:::i;:::-;9522:4;9515:5;9511:16;9504:75;9430:160;9656:3;9700:49;9745:3;9736:6;9725:9;9721:22;9700:49;:::i;:::-;9691:6;9684:5;9680:18;9673:77;9600:161;9850:3;9839:9;9835:19;9822:33;9882:18;9874:6;9871:30;9868:117;;;9904:79;;:::i;:::-;9868:117;10026:58;10080:3;10071:6;10060:9;10056:22;10026:58;:::i;:::-;10017:6;10010:5;10006:18;9999:86;9771:325;8016:2087;;;;:::o;10157:1277::-;10240:5;10284:4;10272:9;10267:3;10263:19;10259:30;10256:117;;;10292:79;;:::i;:::-;10256:117;10391:21;10407:4;10391:21;:::i;:::-;10382:30;;10500:1;10489:9;10485:17;10472:31;10530:18;10522:6;10519:30;10516:117;;;10552:79;;:::i;:::-;10516:117;10672:73;10741:3;10732:6;10721:9;10717:22;10672:73;:::i;:::-;10665:4;10658:5;10654:16;10647:99;10422:335;10849:2;10838:9;10834:18;10821:32;10880:18;10872:6;10869:30;10866:117;;;10902:79;;:::i;:::-;10866:117;11022:58;11076:3;11067:6;11056:9;11052:22;11022:58;:::i;:::-;11015:4;11008:5;11004:16;10997:84;10767:325;11159:2;11200:49;11245:3;11236:6;11225:9;11221:22;11200:49;:::i;:::-;11193:4;11186:5;11182:16;11175:75;11102:159;11325:2;11366:49;11411:3;11402:6;11391:9;11387:22;11366:49;:::i;:::-;11359:4;11352:5;11348:16;11341:75;11271:156;10157:1277;;;;:::o;11490:1017::-;11620:5;11645:115;11661:98;11752:6;11661:98;:::i;:::-;11645:115;:::i;:::-;11636:124;;11780:5;11809:6;11802:5;11795:21;11843:4;11836:5;11832:16;11825:23;;11896:4;11888:6;11884:17;11876:6;11872:30;11925:3;11917:6;11914:15;11911:122;;;11944:79;;:::i;:::-;11911:122;12059:6;12042:459;12076:6;12071:3;12068:15;12042:459;;;12165:3;12152:17;12201:18;12188:11;12185:35;12182:122;;;12223:79;;:::i;:::-;12182:122;12347:11;12339:6;12335:24;12385:71;12452:3;12440:10;12385:71;:::i;:::-;12380:3;12373:84;12486:4;12481:3;12477:14;12470:21;;12118:383;;12102:4;12097:3;12093:14;12086:21;;12042:459;;;12046:21;11626:881;;11490:1017;;;;;:::o;12563:438::-;12668:5;12717:3;12710:4;12702:6;12698:17;12694:27;12684:122;;12725:79;;:::i;:::-;12684:122;12842:6;12829:20;12867:128;12991:3;12983:6;12976:4;12968:6;12964:17;12867:128;:::i;:::-;12858:137;;12674:327;12563:438;;;;:::o;13007:341::-;13114:4;13204:18;13196:6;13193:30;13190:56;;;13226:18;;:::i;:::-;13190:56;13276:4;13268:6;13264:17;13256:25;;13336:4;13330;13326:15;13318:23;;13007:341;;;:::o;13398:595::-;13477:5;13521:4;13509:9;13504:3;13500:19;13496:30;13493:117;;;13529:79;;:::i;:::-;13493:117;13628:21;13644:4;13628:21;:::i;:::-;13619:30;;13716:1;13756:49;13801:3;13792:6;13781:9;13777:22;13756:49;:::i;:::-;13749:4;13742:5;13738:16;13731:75;13659:158;13884:2;13925:49;13970:3;13961:6;13950:9;13946:22;13925:49;:::i;:::-;13918:4;13911:5;13907:16;13900:75;13827:159;13398:595;;;;:::o;14045:800::-;14171:5;14196:111;14212:94;14299:6;14212:94;:::i;:::-;14196:111;:::i;:::-;14187:120;;14327:5;14356:6;14349:5;14342:21;14390:4;14383:5;14379:16;14372:23;;14443:4;14435:6;14431:17;14423:6;14419:30;14472:3;14464:6;14461:15;14458:122;;;14491:79;;:::i;:::-;14458:122;14606:6;14589:250;14623:6;14618:3;14615:15;14589:250;;;14698:3;14727:67;14790:3;14778:10;14727:67;:::i;:::-;14722:3;14715:80;14824:4;14819:3;14815:14;14808:21;;14665:174;14649:4;14644:3;14640:14;14633:21;;14589:250;;;14593:21;14177:668;;14045:800;;;;;:::o;14897:430::-;14998:5;15047:3;15040:4;15032:6;15028:17;15024:27;15014:122;;15055:79;;:::i;:::-;15014:122;15172:6;15159:20;15197:124;15317:3;15309:6;15302:4;15294:6;15290:17;15197:124;:::i;:::-;15188:133;;15004:323;14897:430;;;;:::o;15333:111::-;15385:7;15414:24;15432:5;15414:24;:::i;:::-;15403:35;;15333:111;;;:::o;15450:152::-;15538:39;15571:5;15538:39;:::i;:::-;15531:5;15528:50;15518:78;;15592:1;15589;15582:12;15518:78;15450:152;:::o;15608:169::-;15669:5;15707:6;15694:20;15685:29;;15723:48;15765:5;15723:48;:::i;:::-;15608:169;;;;:::o;15783:1489::-;16007:6;16015;16023;16031;16039;16088:3;16076:9;16067:7;16063:23;16059:33;16056:120;;;16095:79;;:::i;:::-;16056:120;16215:1;16240:53;16285:7;16276:6;16265:9;16261:22;16240:53;:::i;:::-;16230:63;;16186:117;16370:2;16359:9;16355:18;16342:32;16401:18;16393:6;16390:30;16387:117;;;16423:79;;:::i;:::-;16387:117;16528:112;16632:7;16623:6;16612:9;16608:22;16528:112;:::i;:::-;16518:122;;16313:337;16717:2;16706:9;16702:18;16689:32;16748:18;16740:6;16737:30;16734:117;;;16770:79;;:::i;:::-;16734:117;16875:108;16975:7;16966:6;16955:9;16951:22;16875:108;:::i;:::-;16865:118;;16660:333;17032:2;17058:68;17118:7;17109:6;17098:9;17094:22;17058:68;:::i;:::-;17048:78;;17003:133;17175:3;17202:53;17247:7;17238:6;17227:9;17223:22;17202:53;:::i;:::-;17192:63;;17146:119;15783:1489;;;;;;;;:::o;17278:118::-;17365:24;17383:5;17365:24;:::i;:::-;17360:3;17353:37;17278:118;;:::o;17402:222::-;17495:4;17533:2;17522:9;17518:18;17510:26;;17546:71;17614:1;17603:9;17599:17;17590:6;17546:71;:::i;:::-;17402:222;;;;:::o;17630:537::-;17713:6;17762:2;17750:9;17741:7;17737:23;17733:32;17730:119;;;17768:79;;:::i;:::-;17730:119;17916:1;17905:9;17901:17;17888:31;17946:18;17938:6;17935:30;17932:117;;;17968:79;;:::i;:::-;17932:117;18073:77;18142:7;18133:6;18122:9;18118:22;18073:77;:::i;:::-;18063:87;;17859:301;17630:537;;;;:::o;18173:77::-;18210:7;18239:5;18228:16;;18173:77;;;:::o;18256:118::-;18343:24;18361:5;18343:24;:::i;:::-;18338:3;18331:37;18256:118;;:::o;18380:222::-;18473:4;18511:2;18500:9;18496:18;18488:26;;18524:71;18592:1;18581:9;18577:17;18568:6;18524:71;:::i;:::-;18380:222;;;;:::o;18608:90::-;18642:7;18685:5;18678:13;18671:21;18660:32;;18608:90;;;:::o;18704:109::-;18785:21;18800:5;18785:21;:::i;:::-;18780:3;18773:34;18704:109;;:::o;18819:210::-;18906:4;18944:2;18933:9;18929:18;18921:26;;18957:65;19019:1;19008:9;19004:17;18995:6;18957:65;:::i;:::-;18819:210;;;;:::o;19035:329::-;19094:6;19143:2;19131:9;19122:7;19118:23;19114:32;19111:119;;;19149:79;;:::i;:::-;19111:119;19269:1;19294:53;19339:7;19330:6;19319:9;19315:22;19294:53;:::i;:::-;19284:63;;19240:117;19035:329;;;;:::o;19370:118::-;19457:24;19475:5;19457:24;:::i;:::-;19452:3;19445:37;19370:118;;:::o;19494:222::-;19587:4;19625:2;19614:9;19610:18;19602:26;;19638:71;19706:1;19695:9;19691:17;19682:6;19638:71;:::i;:::-;19494:222;;;;:::o;19722:86::-;19757:7;19797:4;19790:5;19786:16;19775:27;;19722:86;;;:::o;19814:118::-;19885:22;19901:5;19885:22;:::i;:::-;19878:5;19875:33;19865:61;;19922:1;19919;19912:12;19865:61;19814:118;:::o;19938:135::-;19982:5;20020:6;20007:20;19998:29;;20036:31;20061:5;20036:31;:::i;:::-;19938:135;;;;:::o;20079:325::-;20136:6;20185:2;20173:9;20164:7;20160:23;20156:32;20153:119;;;20191:79;;:::i;:::-;20153:119;20311:1;20336:51;20379:7;20370:6;20359:9;20355:22;20336:51;:::i;:::-;20326:61;;20282:115;20079:325;;;;:::o;20410:117::-;20519:1;20516;20509:12;20571:231;20643:5;20684:3;20675:6;20670:3;20666:16;20662:26;20659:113;;;20691:79;;:::i;:::-;20659:113;20790:6;20781:15;;20571:231;;;;:::o;20808:541::-;20893:6;20942:2;20930:9;20921:7;20917:23;20913:32;20910:119;;;20948:79;;:::i;:::-;20910:119;21096:1;21085:9;21081:17;21068:31;21126:18;21118:6;21115:30;21112:117;;;21148:79;;:::i;:::-;21112:117;21253:79;21324:7;21315:6;21304:9;21300:22;21253:79;:::i;:::-;21243:89;;21039:303;20808:541;;;;:::o;21355:149::-;21391:7;21431:66;21424:5;21420:78;21409:89;;21355:149;;;:::o;21510:115::-;21595:23;21612:5;21595:23;:::i;:::-;21590:3;21583:36;21510:115;;:::o;21631:99::-;21683:6;21717:5;21711:12;21701:22;;21631:99;;;:::o;21736:169::-;21820:11;21854:6;21849:3;21842:19;21894:4;21889:3;21885:14;21870:29;;21736:169;;;;:::o;21911:246::-;21992:1;22002:113;22016:6;22013:1;22010:13;22002:113;;;22101:1;22096:3;22092:11;22086:18;22082:1;22077:3;22073:11;22066:39;22038:2;22035:1;22031:10;22026:15;;22002:113;;;22149:1;22140:6;22135:3;22131:16;22124:27;21973:184;21911:246;;;:::o;22163:377::-;22251:3;22279:39;22312:5;22279:39;:::i;:::-;22334:71;22398:6;22393:3;22334:71;:::i;:::-;22327:78;;22414:65;22472:6;22467:3;22460:4;22453:5;22449:16;22414:65;:::i;:::-;22504:29;22526:6;22504:29;:::i;:::-;22499:3;22495:39;22488:46;;22255:285;22163:377;;;;:::o;22546:1215::-;22895:4;22933:3;22922:9;22918:19;22910:27;;22947:69;23013:1;23002:9;22998:17;22989:6;22947:69;:::i;:::-;23063:9;23057:4;23053:20;23048:2;23037:9;23033:18;23026:48;23091:78;23164:4;23155:6;23091:78;:::i;:::-;23083:86;;23216:9;23210:4;23206:20;23201:2;23190:9;23186:18;23179:48;23244:78;23317:4;23308:6;23244:78;:::i;:::-;23236:86;;23332:72;23400:2;23389:9;23385:18;23376:6;23332:72;:::i;:::-;23414:73;23482:3;23471:9;23467:19;23458:6;23414:73;:::i;:::-;23497;23565:3;23554:9;23550:19;23541:6;23497:73;:::i;:::-;23618:9;23612:4;23608:20;23602:3;23591:9;23587:19;23580:49;23646:108;23749:4;23740:6;23646:108;:::i;:::-;23638:116;;22546:1215;;;;;;;;;;:::o;23767:149::-;23803:7;23843:66;23836:5;23832:78;23821:89;;23767:149;;;:::o;23922:115::-;24007:23;24024:5;24007:23;:::i;:::-;24002:3;23995:36;23922:115;;:::o;24043:218::-;24134:4;24172:2;24161:9;24157:18;24149:26;;24185:69;24251:1;24240:9;24236:17;24227:6;24185:69;:::i;:::-;24043:218;;;;:::o;24307:594::-;24406:8;24416:6;24466:3;24459:4;24451:6;24447:17;24443:27;24433:122;;24474:79;;:::i;:::-;24433:122;24587:6;24574:20;24564:30;;24617:18;24609:6;24606:30;24603:117;;;24639:79;;:::i;:::-;24603:117;24753:4;24745:6;24741:17;24729:29;;24807:3;24799:4;24791:6;24787:17;24777:8;24773:32;24770:41;24767:128;;;24814:79;;:::i;:::-;24767:128;24307:594;;;;;:::o;24907:611::-;25019:6;25027;25076:2;25064:9;25055:7;25051:23;25047:32;25044:119;;;25082:79;;:::i;:::-;25044:119;25230:1;25219:9;25215:17;25202:31;25260:18;25252:6;25249:30;25246:117;;;25282:79;;:::i;:::-;25246:117;25395:106;25493:7;25484:6;25473:9;25469:22;25395:106;:::i;:::-;25377:124;;;;25173:338;24907:611;;;;;:::o;25574:604::-;25683:8;25693:6;25743:3;25736:4;25728:6;25724:17;25720:27;25710:122;;25751:79;;:::i;:::-;25710:122;25864:6;25851:20;25841:30;;25894:18;25886:6;25883:30;25880:117;;;25916:79;;:::i;:::-;25880:117;26030:4;26022:6;26018:17;26006:29;;26084:3;26076:4;26068:6;26064:17;26054:8;26050:32;26047:41;26044:128;;;26091:79;;:::i;:::-;26044:128;25574:604;;;;;:::o;26184:631::-;26306:6;26314;26363:2;26351:9;26342:7;26338:23;26334:32;26331:119;;;26369:79;;:::i;:::-;26331:119;26517:1;26506:9;26502:17;26489:31;26547:18;26539:6;26536:30;26533:117;;;26569:79;;:::i;:::-;26533:117;26682:116;26790:7;26781:6;26770:9;26766:22;26682:116;:::i;:::-;26664:134;;;;26460:348;26184:631;;;;;:::o;26821:144::-;26918:6;26952:5;26946:12;26936:22;;26821:144;;;:::o;26971:214::-;27100:11;27134:6;27129:3;27122:19;27174:4;27169:3;27165:14;27150:29;;26971:214;;;;:::o;27191:162::-;27288:4;27311:3;27303:11;;27341:4;27336:3;27332:14;27324:22;;27191:162;;;:::o;27443:523::-;27590:4;27585:3;27581:14;27685:4;27678:5;27674:16;27668:23;27704:63;27761:4;27756:3;27752:14;27738:12;27704:63;:::i;:::-;27605:172;27867:4;27860:5;27856:16;27850:23;27886:63;27943:4;27938:3;27934:14;27920:12;27886:63;:::i;:::-;27787:172;27559:407;27443:523;;:::o;27972:299::-;28101:10;28122:106;28224:3;28216:6;28122:106;:::i;:::-;28260:4;28255:3;28251:14;28237:28;;27972:299;;;;:::o;28277:143::-;28377:4;28409;28404:3;28400:14;28392:22;;28277:143;;;:::o;28514:972::-;28693:3;28722:84;28800:5;28722:84;:::i;:::-;28822:116;28931:6;28926:3;28822:116;:::i;:::-;28815:123;;28962:86;29042:5;28962:86;:::i;:::-;29071:7;29102:1;29087:374;29112:6;29109:1;29106:13;29087:374;;;29188:6;29182:13;29215:123;29334:3;29319:13;29215:123;:::i;:::-;29208:130;;29361:90;29444:6;29361:90;:::i;:::-;29351:100;;29147:314;29134:1;29131;29127:9;29122:14;;29087:374;;;29091:14;29477:3;29470:10;;28698:788;;;28514:972;;;;:::o;29492:824::-;29779:4;29817:3;29806:9;29802:19;29794:27;;29867:9;29861:4;29857:20;29853:1;29842:9;29838:17;29831:47;29895:168;30058:4;30049:6;29895:168;:::i;:::-;29887:176;;30073:72;30141:2;30130:9;30126:18;30117:6;30073:72;:::i;:::-;30155;30223:2;30212:9;30208:18;30199:6;30155:72;:::i;:::-;30237;30305:2;30294:9;30290:18;30281:6;30237:72;:::i;:::-;29492:824;;;;;;;:::o;30322:619::-;30399:6;30407;30415;30464:2;30452:9;30443:7;30439:23;30435:32;30432:119;;;30470:79;;:::i;:::-;30432:119;30590:1;30615:53;30660:7;30651:6;30640:9;30636:22;30615:53;:::i;:::-;30605:63;;30561:117;30717:2;30743:53;30788:7;30779:6;30768:9;30764:22;30743:53;:::i;:::-;30733:63;;30688:118;30845:2;30871:53;30916:7;30907:6;30896:9;30892:22;30871:53;:::i;:::-;30861:63;;30816:118;30322:619;;;;;:::o;30947:474::-;31015:6;31023;31072:2;31060:9;31051:7;31047:23;31043:32;31040:119;;;31078:79;;:::i;:::-;31040:119;31198:1;31223:53;31268:7;31259:6;31248:9;31244:22;31223:53;:::i;:::-;31213:63;;31169:117;31325:2;31351:53;31396:7;31387:6;31376:9;31372:22;31351:53;:::i;:::-;31341:63;;31296:118;30947:474;;;;;:::o;31427:180::-;31475:77;31472:1;31465:88;31572:4;31569:1;31562:15;31596:4;31593:1;31586:15;31613:442;31762:4;31800:2;31789:9;31785:18;31777:26;;31813:71;31881:1;31870:9;31866:17;31857:6;31813:71;:::i;:::-;31894:72;31962:2;31951:9;31947:18;31938:6;31894:72;:::i;:::-;31976;32044:2;32033:9;32029:18;32020:6;31976:72;:::i;:::-;31613:442;;;;;;:::o;32061:116::-;32131:21;32146:5;32131:21;:::i;:::-;32124:5;32121:32;32111:60;;32167:1;32164;32157:12;32111:60;32061:116;:::o;32183:137::-;32237:5;32268:6;32262:13;32253:22;;32284:30;32308:5;32284:30;:::i;:::-;32183:137;;;;:::o;32326:345::-;32393:6;32442:2;32430:9;32421:7;32417:23;32413:32;32410:119;;;32448:79;;:::i;:::-;32410:119;32568:1;32593:61;32646:7;32637:6;32626:9;32622:22;32593:61;:::i;:::-;32583:71;;32539:125;32326:345;;;;:::o;32677:332::-;32798:4;32836:2;32825:9;32821:18;32813:26;;32849:71;32917:1;32906:9;32902:17;32893:6;32849:71;:::i;:::-;32930:72;32998:2;32987:9;32983:18;32974:6;32930:72;:::i;:::-;32677:332;;;;;:::o;33015:::-;33136:4;33174:2;33163:9;33159:18;33151:26;;33187:71;33255:1;33244:9;33240:17;33231:6;33187:71;:::i;:::-;33268:72;33336:2;33325:9;33321:18;33312:6;33268:72;:::i;:::-;33015:332;;;;;:::o;33353:180::-;33401:77;33398:1;33391:88;33498:4;33495:1;33488:15;33522:4;33519:1;33512:15;33539:120;33627:1;33620:5;33617:12;33607:46;;33633:18;;:::i;:::-;33607:46;33539:120;:::o;33665:141::-;33717:7;33746:5;33735:16;;33752:48;33794:5;33752:48;:::i;:::-;33665:141;;;:::o;33812:::-;33875:9;33908:39;33941:5;33908:39;:::i;:::-;33895:52;;33812:141;;;:::o;33959:147::-;34049:50;34093:5;34049:50;:::i;:::-;34044:3;34037:63;33959:147;;:::o;34112:108::-;34189:24;34207:5;34189:24;:::i;:::-;34184:3;34177:37;34112:108;;:::o;34310:1780::-;34467:6;34462:3;34458:16;34556:4;34549:5;34545:16;34539:23;34575:63;34632:4;34627:3;34623:14;34609:12;34575:63;:::i;:::-;34484:164;34732:4;34725:5;34721:16;34715:23;34751:63;34808:4;34803:3;34799:14;34785:12;34751:63;:::i;:::-;34658:166;34907:4;34900:5;34896:16;34890:23;34926:63;34983:4;34978:3;34974:14;34960:12;34926:63;:::i;:::-;34834:165;35086:4;35079:5;35075:16;35069:23;35105:76;35175:4;35170:3;35166:14;35152:12;35105:76;:::i;:::-;35009:182;35271:4;35264:5;35260:16;35254:23;35290:63;35347:4;35342:3;35338:14;35324:12;35290:63;:::i;:::-;35201:162;35446:4;35439:5;35435:16;35429:23;35465:63;35522:4;35517:3;35513:14;35499:12;35465:63;:::i;:::-;35373:165;35624:4;35617:5;35613:16;35607:23;35643:63;35700:4;35695:3;35691:14;35677:12;35643:63;:::i;:::-;35548:168;35806:4;35799:5;35795:16;35789:23;35825:63;35882:4;35877:3;35873:14;35859:12;35825:63;:::i;:::-;35726:172;35987:6;35980:5;35976:18;35970:25;36008:65;36065:6;36060:3;36056:16;36042:12;36008:65;:::i;:::-;35908:175;34436:1654;34310:1780;;:::o;36096:564::-;36305:4;36343:3;36332:9;36328:19;36320:27;;36357:71;36425:1;36414:9;36410:17;36401:6;36357:71;:::i;:::-;36438:132;36566:2;36555:9;36551:18;36542:6;36438:132;:::i;:::-;36580:73;36648:3;36637:9;36633:19;36624:6;36580:73;:::i;:::-;36096:564;;;;;;:::o;36666:180::-;36714:77;36711:1;36704:88;36811:4;36808:1;36801:15;36835:4;36832:1;36825:15;36852:191;36892:3;36911:20;36929:1;36911:20;:::i;:::-;36906:25;;36945:20;36963:1;36945:20;:::i;:::-;36940:25;;36988:1;36985;36981:9;36974:16;;37009:3;37006:1;37003:10;37000:36;;;37016:18;;:::i;:::-;37000:36;36852:191;;;;:::o;37049:194::-;37089:4;37109:20;37127:1;37109:20;:::i;:::-;37104:25;;37143:20;37161:1;37143:20;:::i;:::-;37138:25;;37187:1;37184;37180:9;37172:17;;37211:1;37205:4;37202:11;37199:37;;;37216:18;;:::i;:::-;37199:37;37049:194;;;;:::o;37249:332::-;37370:4;37408:2;37397:9;37393:18;37385:26;;37421:71;37489:1;37478:9;37474:17;37465:6;37421:71;:::i;:::-;37502:72;37570:2;37559:9;37555:18;37546:6;37502:72;:::i;:::-;37249:332;;;;;:::o;37587:208::-;37687:9;37721:67;37773:14;37766:5;37721:67;:::i;:::-;37708:80;;37587:208;;;:::o;37801:332::-;37922:4;37960:2;37949:9;37945:18;37937:26;;37973:71;38041:1;38030:9;38026:17;38017:6;37973:71;:::i;:::-;38054:72;38122:2;38111:9;38107:18;38098:6;38054:72;:::i;:::-;37801:332;;;;;:::o;38139:171::-;38279:23;38275:1;38267:6;38263:14;38256:47;38139:171;:::o;38316:366::-;38458:3;38479:67;38543:2;38538:3;38479:67;:::i;:::-;38472:74;;38555:93;38644:3;38555:93;:::i;:::-;38673:2;38668:3;38664:12;38657:19;;38316:366;;;:::o;38688:419::-;38854:4;38892:2;38881:9;38877:18;38869:26;;38941:9;38935:4;38931:20;38927:1;38916:9;38912:17;38905:47;38969:131;39095:4;38969:131;:::i;:::-;38961:139;;38688:419;;;:::o;39113:117::-;39222:1;39219;39212:12;39482:394;39574:4;39628:11;39615:25;39730:1;39722:6;39718:14;39707:8;39691:14;39687:29;39683:50;39663:18;39659:75;39649:170;;39738:79;;:::i;:::-;39649:170;39850:18;39840:8;39836:33;39828:41;;39579:297;39482:394;;;;:::o;39882:402::-;39984:4;40038:11;40025:25;40138:1;40132:4;40128:12;40117:8;40101:14;40097:29;40093:48;40073:18;40069:73;40059:168;;40146:79;;:::i;:::-;40059:168;40258:18;40248:8;40244:33;40236:41;;39989:295;39882:402;;;;:::o;40290:359::-;40364:6;40413:2;40401:9;40392:7;40388:23;40384:32;40381:119;;;40419:79;;:::i;:::-;40381:119;40539:1;40564:68;40624:7;40615:6;40604:9;40600:22;40564:68;:::i;:::-;40554:78;;40510:132;40290:359;;;;:::o;40655:233::-;40694:3;40717:24;40735:5;40717:24;:::i;:::-;40708:33;;40763:66;40756:5;40753:77;40750:103;;40833:18;;:::i;:::-;40750:103;40880:1;40873:5;40869:13;40862:20;;40655:233;;;:::o;40894:238::-;41014:9;41048:77;41110:14;41103:5;41048:77;:::i;:::-;41035:90;;40894:238;;;:::o;41138:85::-;41183:7;41212:5;41201:16;;41138:85;;;:::o;41229:101::-;41265:7;41305:18;41298:5;41294:30;41283:41;;41229:101;;;:::o;41336:60::-;41364:3;41385:5;41378:12;;41336:60;;;:::o;41402:156::-;41459:9;41492:60;41509:42;41518:32;41544:5;41518:32;:::i;:::-;41509:42;:::i;:::-;41492:60;:::i;:::-;41479:73;;41402:156;;;:::o;41564:145::-;41658:44;41696:5;41658:44;:::i;:::-;41653:3;41646:57;41564:145;;:::o;41715:236::-;41815:4;41853:2;41842:9;41838:18;41830:26;;41866:78;41941:1;41930:9;41926:17;41917:6;41866:78;:::i;:::-;41715:236;;;;:::o;41957:143::-;42014:5;42045:6;42039:13;42030:22;;42061:33;42088:5;42061:33;:::i;:::-;41957:143;;;;:::o;42106:351::-;42176:6;42225:2;42213:9;42204:7;42200:23;42196:32;42193:119;;;42231:79;;:::i;:::-;42193:119;42351:1;42376:64;42432:7;42423:6;42412:9;42408:22;42376:64;:::i;:::-;42366:74;;42322:128;42106:351;;;;:::o;42463:104::-;42508:7;42537:24;42555:5;42537:24;:::i;:::-;42526:35;;42463:104;;;:::o;42573:138::-;42654:32;42680:5;42654:32;:::i;:::-;42647:5;42644:43;42634:71;;42701:1;42698;42691:12;42634:71;42573:138;:::o;42717:159::-;42782:5;42813:6;42807:13;42798:22;;42829:41;42864:5;42829:41;:::i;:::-;42717:159;;;;:::o;42882:143::-;42939:5;42970:6;42964:13;42955:22;;42986:33;43013:5;42986:33;:::i;:::-;42882:143;;;;:::o;43031:139::-;43086:5;43117:6;43111:13;43102:22;;43133:31;43158:5;43133:31;:::i;:::-;43031:139;;;;:::o;43176:122::-;43249:24;43267:5;43249:24;:::i;:::-;43242:5;43239:35;43229:63;;43288:1;43285;43278:12;43229:63;43176:122;:::o;43304:143::-;43361:5;43392:6;43386:13;43377:22;;43408:33;43435:5;43408:33;:::i;:::-;43304:143;;;;:::o;43453:1319::-;43591:6;43599;43607;43615;43623;43631;43639;43688:3;43676:9;43667:7;43663:23;43659:33;43656:120;;;43695:79;;:::i;:::-;43656:120;43815:1;43840:72;43904:7;43895:6;43884:9;43880:22;43840:72;:::i;:::-;43830:82;;43786:136;43961:2;43987:72;44051:7;44042:6;44031:9;44027:22;43987:72;:::i;:::-;43977:82;;43932:137;44108:2;44134:64;44190:7;44181:6;44170:9;44166:22;44134:64;:::i;:::-;44124:74;;44079:129;44247:2;44273:64;44329:7;44320:6;44309:9;44305:22;44273:64;:::i;:::-;44263:74;;44218:129;44386:3;44413:62;44467:7;44458:6;44447:9;44443:22;44413:62;:::i;:::-;44403:72;;44357:128;44524:3;44551:64;44607:7;44598:6;44587:9;44583:22;44551:64;:::i;:::-;44541:74;;44495:130;44664:3;44691:64;44747:7;44738:6;44727:9;44723:22;44691:64;:::i;:::-;44681:74;;44635:130;43453:1319;;;;;;;;;;:::o;44778:112::-;44861:22;44877:5;44861:22;:::i;:::-;44856:3;44849:35;44778:112;;:::o;44896:878::-;45153:4;45191:3;45180:9;45176:19;45168:27;;45205:71;45273:1;45262:9;45258:17;45249:6;45205:71;:::i;:::-;45286:72;45354:2;45343:9;45339:18;45330:6;45286:72;:::i;:::-;45368;45436:2;45425:9;45421:18;45412:6;45368:72;:::i;:::-;45450;45518:2;45507:9;45503:18;45494:6;45450:72;:::i;:::-;45532:69;45596:3;45585:9;45581:19;45572:6;45532:69;:::i;:::-;45611:73;45679:3;45668:9;45664:19;45655:6;45611:73;:::i;:::-;45694;45762:3;45751:9;45747:19;45738:6;45694:73;:::i;:::-;44896:878;;;;;;;;;;:::o;45780:117::-;45889:1;45886;45879:12;45903:117;46012:1;46009;46002:12;46026:469;46131:9;46142;46180:8;46168:10;46165:24;46162:111;;;46192:79;;:::i;:::-;46162:111;46298:6;46288:8;46285:20;46282:107;;;46308:79;;:::i;:::-;46282:107;46439:1;46427:10;46423:18;46415:6;46411:31;46398:44;;46478:10;46468:8;46464:25;46451:38;;46026:469;;;;;;;:::o;46501:96::-;46559:6;46587:3;46577:13;;46501:96;;;;:::o;46695:107::-;46739:8;46789:5;46783:4;46779:16;46758:37;;46695:107;;;;:::o;46808:548::-;46898:5;46929:45;46970:3;46963:5;46929:45;:::i;:::-;46999:5;47023:40;47053:8;47040:22;47023:40;:::i;:::-;47014:49;;47087:1;47079:6;47076:13;47073:276;;;47157:168;47241:66;47211:6;47208:1;47204:14;47201:1;47197:22;47157:168;:::i;:::-;47134:5;47113:226;47104:235;;47073:276;46904:452;;46808:548;;;;:::o;47362:168::-;47445:11;47479:6;47474:3;47467:19;47519:4;47514:3;47510:14;47495:29;;47362:168;;;;:::o;47558:314::-;47654:3;47675:70;47738:6;47733:3;47675:70;:::i;:::-;47668:77;;47755:56;47804:6;47799:3;47792:5;47755:56;:::i;:::-;47836:29;47858:6;47836:29;:::i;:::-;47831:3;47827:39;47820:46;;47558:314;;;;;:::o;47878:439::-;48027:4;48065:2;48054:9;48050:18;48042:26;;48078:71;48146:1;48135:9;48131:17;48122:6;48078:71;:::i;:::-;48196:9;48190:4;48186:20;48181:2;48170:9;48166:18;48159:48;48224:86;48305:4;48296:6;48288;48224:86;:::i;:::-;48216:94;;47878:439;;;;;;:::o;48323:180::-;48371:77;48368:1;48361:88;48468:4;48465:1;48458:15;48492:4;48489:1;48482:15;48509:320;48553:6;48590:1;48584:4;48580:12;48570:22;;48637:1;48631:4;48627:12;48658:18;48648:81;;48714:4;48706:6;48702:17;48692:27;;48648:81;48776:2;48768:6;48765:14;48745:18;48742:38;48739:84;;48795:18;;:::i;:::-;48739:84;48560:269;48509:320;;;:::o;48835:351::-;48905:6;48954:2;48942:9;48933:7;48929:23;48925:32;48922:119;;;48960:79;;:::i;:::-;48922:119;49080:1;49105:64;49161:7;49152:6;49141:9;49137:22;49105:64;:::i;:::-;49095:74;;49051:128;48835:351;;;;:::o;49192:87::-;49239:7;49268:5;49257:16;;49192:87;;;:::o;49285:158::-;49343:9;49376:61;49392:44;49401:34;49429:5;49401:34;:::i;:::-;49392:44;:::i;:::-;49376:61;:::i;:::-;49363:74;;49285:158;;;:::o;49449:147::-;49544:45;49583:5;49544:45;:::i;:::-;49539:3;49532:58;49449:147;;:::o;49602:348::-;49731:4;49769:2;49758:9;49754:18;49746:26;;49782:79;49858:1;49847:9;49843:17;49834:6;49782:79;:::i;:::-;49871:72;49939:2;49928:9;49924:18;49915:6;49871:72;:::i;:::-;49602:348;;;;;:::o;49956:102::-;49998:8;50045:5;50042:1;50038:13;50017:34;;49956:102;;;:::o;50064:848::-;50125:5;50132:4;50156:6;50147:15;;50180:5;50171:14;;50194:712;50215:1;50205:8;50202:15;50194:712;;;50310:4;50305:3;50301:14;50295:4;50292:24;50289:50;;;50319:18;;:::i;:::-;50289:50;50369:1;50359:8;50355:16;50352:451;;;50784:4;50777:5;50773:16;50764:25;;50352:451;50834:4;50828;50824:15;50816:23;;50864:32;50887:8;50864:32;:::i;:::-;50852:44;;50194:712;;;50064:848;;;;;;;:::o;50918:1073::-;50972:5;51163:8;51153:40;;51184:1;51175:10;;51186:5;;51153:40;51212:4;51202:36;;51229:1;51220:10;;51231:5;;51202:36;51298:4;51346:1;51341:27;;;;51382:1;51377:191;;;;51291:277;;51341:27;51359:1;51350:10;;51361:5;;;51377:191;51422:3;51412:8;51409:17;51406:43;;;51429:18;;:::i;:::-;51406:43;51478:8;51475:1;51471:16;51462:25;;51513:3;51506:5;51503:14;51500:40;;;51520:18;;:::i;:::-;51500:40;51553:5;;;51291:277;;51677:2;51667:8;51664:16;51658:3;51652:4;51649:13;51645:36;51627:2;51617:8;51614:16;51609:2;51603:4;51600:12;51596:35;51580:111;51577:246;;;51733:8;51727:4;51723:19;51714:28;;51768:3;51761:5;51758:14;51755:40;;;51775:18;;:::i;:::-;51755:40;51808:5;;51577:246;51848:42;51886:3;51876:8;51870:4;51867:1;51848:42;:::i;:::-;51833:57;;;;51922:4;51917:3;51913:14;51906:5;51903:25;51900:51;;;51931:18;;:::i;:::-;51900:51;51980:4;51973:5;51969:16;51960:25;;50918:1073;;;;;;:::o;51997:285::-;52057:5;52081:23;52099:4;52081:23;:::i;:::-;52073:31;;52125:27;52143:8;52125:27;:::i;:::-;52113:39;;52171:104;52208:66;52198:8;52192:4;52171:104;:::i;:::-;52162:113;;51997:285;;;;:::o;52288:410::-;52328:7;52351:20;52369:1;52351:20;:::i;:::-;52346:25;;52385:20;52403:1;52385:20;:::i;:::-;52380:25;;52440:1;52437;52433:9;52462:30;52480:11;52462:30;:::i;:::-;52451:41;;52641:1;52632:7;52628:15;52625:1;52622:22;52602:1;52595:9;52575:83;52552:139;;52671:18;;:::i;:::-;52552:139;52336:362;52288:410;;;;:::o;52704:180::-;52752:77;52749:1;52742:88;52849:4;52846:1;52839:15;52873:4;52870:1;52863:15;52890:185;52930:1;52947:20;52965:1;52947:20;:::i;:::-;52942:25;;52981:20;52999:1;52981:20;:::i;:::-;52976:25;;53020:1;53010:35;;53025:18;;:::i;:::-;53010:35;53067:1;53064;53060:9;53055:14;;52890:185;;;;:::o;53081:438::-;53228:4;53266:2;53255:9;53251:18;53243:26;;53279:71;53347:1;53336:9;53332:17;53323:6;53279:71;:::i;:::-;53360:72;53428:2;53417:9;53413:18;53404:6;53360:72;:::i;:::-;53442:70;53508:2;53497:9;53493:18;53484:6;53442:70;:::i;:::-;53081:438;;;;;;:::o;53525:98::-;53576:6;53610:5;53604:12;53594:22;;53525:98;;;:::o;53629:373::-;53715:3;53743:38;53775:5;53743:38;:::i;:::-;53797:70;53860:6;53855:3;53797:70;:::i;:::-;53790:77;;53876:65;53934:6;53929:3;53922:4;53915:5;53911:16;53876:65;:::i;:::-;53966:29;53988:6;53966:29;:::i;:::-;53961:3;53957:39;53950:46;;53719:283;53629:373;;;;:::o;54008:419::-;54147:4;54185:2;54174:9;54170:18;54162:26;;54198:71;54266:1;54255:9;54251:17;54242:6;54198:71;:::i;:::-;54316:9;54310:4;54306:20;54301:2;54290:9;54286:18;54279:48;54344:76;54415:4;54406:6;54344:76;:::i;:::-;54336:84;;54008:419;;;;;:::o;54433:147::-;54534:11;54571:3;54556:18;;54433:147;;;;:::o;54586:386::-;54690:3;54718:38;54750:5;54718:38;:::i;:::-;54772:88;54853:6;54848:3;54772:88;:::i;:::-;54765:95;;54869:65;54927:6;54922:3;54915:4;54908:5;54904:16;54869:65;:::i;:::-;54959:6;54954:3;54950:16;54943:23;;54694:278;54586:386;;;;:::o;54978:271::-;55108:3;55130:93;55219:3;55210:6;55130:93;:::i;:::-;55123:100;;55240:3;55233:10;;54978:271;;;;:::o;55255:351::-;55325:6;55374:2;55362:9;55353:7;55349:23;55345:32;55342:119;;;55380:79;;:::i;:::-;55342:119;55500:1;55525:64;55581:7;55572:6;55561:9;55557:22;55525:64;:::i;:::-;55515:74;;55471:128;55255:351;;;;:::o;55612:76::-;55648:7;55677:5;55666:16;;55612:76;;;:::o;55694:385::-;55733:1;55750:19;55767:1;55750:19;:::i;:::-;55745:24;;55783:19;55800:1;55783:19;:::i;:::-;55778:24;;55821:1;55811:35;;55826:18;;:::i;:::-;55811:35;56012:1;56009;56005:9;56002:1;55999:16;55918:66;55915:1;55912:73;55895:130;55892:156;;;56028:18;;:::i;:::-;55892:156;56071:1;56068;56063:10;56058:15;;55694:385;;;;:::o;56085:375::-;56124:3;56143:19;56160:1;56143:19;:::i;:::-;56138:24;;56176:19;56193:1;56176:19;:::i;:::-;56171:24;;56218:1;56215;56211:9;56204:16;;56416:1;56411:3;56407:11;56400:19;56396:1;56393;56389:9;56385:35;56368:1;56363:3;56359:11;56354:1;56351;56347:9;56340:17;56336:35;56320:110;56317:136;;;56433:18;;:::i;:::-;56317:136;56085:375;;;;:::o;56466:556::-;56505:7;56528:19;56545:1;56528:19;:::i;:::-;56523:24;;56561:19;56578:1;56561:19;:::i;:::-;56556:24;;56615:1;56612;56608:9;56637:29;56654:11;56637:29;:::i;:::-;56626:40;;56724:66;56721:1;56718:73;56714:1;56711;56707:9;56703:89;56700:115;;;56795:18;;:::i;:::-;56700:115;56965:1;56956:7;56951:16;56948:1;56945:23;56925:1;56918:9;56898:84;56875:140;;56995:18;;:::i;:::-;56875:140;56513:509;56466:556;;;;:::o;57028:141::-;57077:4;57100:3;57092:11;;57123:3;57120:1;57113:14;57157:4;57154:1;57144:18;57136:26;;57028:141;;;:::o;57175:93::-;57212:6;57259:2;57254;57247:5;57243:14;57239:23;57229:33;;57175:93;;;:::o;57274:393::-;57343:6;57393:1;57381:10;57377:18;57416:97;57446:66;57435:9;57416:97;:::i;:::-;57534:39;57564:8;57553:9;57534:39;:::i;:::-;57522:51;;57606:4;57602:9;57595:5;57591:21;57582:30;;57655:4;57645:8;57641:19;57634:5;57631:30;57621:40;;57350:317;;57274:393;;;;;:::o;57673:142::-;57723:9;57756:53;57774:34;57783:24;57801:5;57783:24;:::i;:::-;57774:34;:::i;:::-;57756:53;:::i;:::-;57743:66;;57673:142;;;:::o;57821:75::-;57864:3;57885:5;57878:12;;57821:75;;;:::o;57902:269::-;58012:39;58043:7;58012:39;:::i;:::-;58073:91;58122:41;58146:16;58122:41;:::i;:::-;58114:6;58107:4;58101:11;58073:91;:::i;:::-;58067:4;58060:105;57978:193;57902:269;;;:::o;58177:73::-;58222:3;58177:73;:::o;58256:189::-;58333:32;;:::i;:::-;58374:65;58432:6;58424;58418:4;58374:65;:::i;:::-;58309:136;58256:189;;:::o;58451:186::-;58511:120;58528:3;58521:5;58518:14;58511:120;;;58582:39;58619:1;58612:5;58582:39;:::i;:::-;58555:1;58548:5;58544:13;58535:22;;58511:120;;;58451:186;;:::o;58643:543::-;58744:2;58739:3;58736:11;58733:446;;;58778:38;58810:5;58778:38;:::i;:::-;58862:29;58880:10;58862:29;:::i;:::-;58852:8;58848:44;59045:2;59033:10;59030:18;59027:49;;;59066:8;59051:23;;59027:49;59089:80;59145:22;59163:3;59145:22;:::i;:::-;59135:8;59131:37;59118:11;59089:80;:::i;:::-;58748:431;;58733:446;58643:543;;;:::o;59192:117::-;59246:8;59296:5;59290:4;59286:16;59265:37;;59192:117;;;;:::o;59315:169::-;59359:6;59392:51;59440:1;59436:6;59428:5;59425:1;59421:13;59392:51;:::i;:::-;59388:56;59473:4;59467;59463:15;59453:25;;59366:118;59315:169;;;;:::o;59489:295::-;59565:4;59711:29;59736:3;59730:4;59711:29;:::i;:::-;59703:37;;59773:3;59770:1;59766:11;59760:4;59757:21;59749:29;;59489:295;;;;:::o;59789:1395::-;59906:37;59939:3;59906:37;:::i;:::-;60008:18;60000:6;59997:30;59994:56;;;60030:18;;:::i;:::-;59994:56;60074:38;60106:4;60100:11;60074:38;:::i;:::-;60159:67;60219:6;60211;60205:4;60159:67;:::i;:::-;60253:1;60277:4;60264:17;;60309:2;60301:6;60298:14;60326:1;60321:618;;;;60983:1;61000:6;60997:77;;;61049:9;61044:3;61040:19;61034:26;61025:35;;60997:77;61100:67;61160:6;61153:5;61100:67;:::i;:::-;61094:4;61087:81;60956:222;60291:887;;60321:618;60373:4;60369:9;60361:6;60357:22;60407:37;60439:4;60407:37;:::i;:::-;60466:1;60480:208;60494:7;60491:1;60488:14;60480:208;;;60573:9;60568:3;60564:19;60558:26;60550:6;60543:42;60624:1;60616:6;60612:14;60602:24;;60671:2;60660:9;60656:18;60643:31;;60517:4;60514:1;60510:12;60505:17;;60480:208;;;60716:6;60707:7;60704:19;60701:179;;;60774:9;60769:3;60765:19;60759:26;60817:48;60859:4;60851:6;60847:17;60836:9;60817:48;:::i;:::-;60809:6;60802:64;60724:156;60701:179;60926:1;60922;60914:6;60910:14;60906:22;60900:4;60893:36;60328:611;;;60291:887;;59881:1303;;;59789:1395;;:::o;61190:664::-;61395:4;61433:3;61422:9;61418:19;61410:27;;61447:71;61515:1;61504:9;61500:17;61491:6;61447:71;:::i;:::-;61528:72;61596:2;61585:9;61581:18;61572:6;61528:72;:::i;:::-;61610;61678:2;61667:9;61663:18;61654:6;61610:72;:::i;:::-;61692;61760:2;61749:9;61745:18;61736:6;61692:72;:::i;:::-;61774:73;61842:3;61831:9;61827:19;61818:6;61774:73;:::i;:::-;61190:664;;;;;;;;:::o;61860:163::-;62000:15;61996:1;61988:6;61984:14;61977:39;61860:163;:::o;62029:366::-;62171:3;62192:67;62256:2;62251:3;62192:67;:::i;:::-;62185:74;;62268:93;62357:3;62268:93;:::i;:::-;62386:2;62381:3;62377:12;62370:19;;62029:366;;;:::o;62401:419::-;62567:4;62605:2;62594:9;62590:18;62582:26;;62654:9;62648:4;62644:20;62640:1;62629:9;62625:17;62618:47;62682:131;62808:4;62682:131;:::i;:::-;62674:139;;62401:419;;;:::o;62826:166::-;62966:18;62962:1;62954:6;62950:14;62943:42;62826:166;:::o;62998:366::-;63140:3;63161:67;63225:2;63220:3;63161:67;:::i;:::-;63154:74;;63237:93;63326:3;63237:93;:::i;:::-;63355:2;63350:3;63346:12;63339:19;;62998:366;;;:::o;63370:419::-;63536:4;63574:2;63563:9;63559:18;63551:26;;63623:9;63617:4;63613:20;63609:1;63598:9;63594:17;63587:47;63651:131;63777:4;63651:131;:::i;:::-;63643:139;;63370:419;;;:::o;63795:165::-;63935:17;63931:1;63923:6;63919:14;63912:41;63795:165;:::o;63966:366::-;64108:3;64129:67;64193:2;64188:3;64129:67;:::i;:::-;64122:74;;64205:93;64294:3;64205:93;:::i;:::-;64323:2;64318:3;64314:12;64307:19;;63966:366;;;:::o;64338:419::-;64504:4;64542:2;64531:9;64527:18;64519:26;;64591:9;64585:4;64581:20;64577:1;64566:9;64562:17;64555:47;64619:131;64745:4;64619:131;:::i;:::-;64611:139;;64338:419;;;:::o;64763:165::-;64903:17;64899:1;64891:6;64887:14;64880:41;64763:165;:::o;64934:366::-;65076:3;65097:67;65161:2;65156:3;65097:67;:::i;:::-;65090:74;;65173:93;65262:3;65173:93;:::i;:::-;65291:2;65286:3;65282:12;65275:19;;64934:366;;;:::o;65306:419::-;65472:4;65510:2;65499:9;65495:18;65487:26;;65559:9;65553:4;65549:20;65545:1;65534:9;65530:17;65523:47;65587:131;65713:4;65587:131;:::i;:::-;65579:139;;65306:419;;;:::o;65731:171::-;65871:23;65867:1;65859:6;65855:14;65848:47;65731:171;:::o;65908:366::-;66050:3;66071:67;66135:2;66130:3;66071:67;:::i;:::-;66064:74;;66147:93;66236:3;66147:93;:::i;:::-;66265:2;66260:3;66256:12;66249:19;;65908:366;;;:::o;66280:419::-;66446:4;66484:2;66473:9;66469:18;66461:26;;66533:9;66527:4;66523:20;66519:1;66508:9;66504:17;66497:47;66561:131;66687:4;66561:131;:::i;:::-;66553:139;;66280:419;;;:::o;66705:545::-;66878:4;66916:3;66905:9;66901:19;66893:27;;66930:71;66998:1;66987:9;66983:17;66974:6;66930:71;:::i;:::-;67011:68;67075:2;67064:9;67060:18;67051:6;67011:68;:::i;:::-;67089:72;67157:2;67146:9;67142:18;67133:6;67089:72;:::i;:::-;67171;67239:2;67228:9;67224:18;67215:6;67171:72;:::i;:::-;66705:545;;;;;;;:::o",
-      "linkReferences":{
-         
-      }
-   },
-   "methodIdentifiers":{
-      "advanceNonce(uint8)":"72c244a8",
-      "authority()":"bf7e214f",
-      "cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes)[])":"ada08449",
-      "cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))":"7db458e5",
-      "eip712Domain()":"84b0196e",
-      "feeRecipient()":"46904840",
-      "hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))":"5bd5f77d",
-      "increaseNonce()":"c53a0292",
-      "initialize(address,address,address)":"c0c53b8b",
-      "isConsumingScheduledOp()":"8fb36037",
-      "nonce(address)":"70ae92d2",
-      "nonceEquals(address,uint256)":"cf6fc6e3",
-      "orderStatuses(bytes32[])":"0c0b8c9c",
-      "orderStatusesRaw(bytes32[])":"35ee3ffc",
-      "pause()":"8456cb59",
-      "paused()":"5c975abb",
-      "router()":"f887ea40",
-      "setAuthority(address)":"7a9e5e4b",
-      "setFeeRecipient(address)":"e74b981b",
-      "setRouter(address)":"c0d78655",
-      "transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256)":"19f752f6",
-      "unpause()":"3f4ba83a",
-      "validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[])":"bd8f1178"
-   },
-   "rawMetadata":"{\"compiler\":{\"version\":\"0.8.24+commit.e11b9ed9\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"authority\",\"type\":\"address\"}],\"name\":\"AccessManagedInvalidAuthority\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"delay\",\"type\":\"uint32\"}],\"name\":\"AccessManagedRequiredDelay\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"}],\"name\":\"AccessManagedUnauthorized\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderId\",\"type\":\"bytes32\"}],\"name\":\"AlreadyFilled\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"EnforcedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ExpectedPause\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"IncompatibleOrderBatch\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidInitialization\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"InvalidOrderType\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"MaxTakingExceeded\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NoValidOrder\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotInitializing\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotMaker\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"NotRouter\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"orderId\",\"type\":\"bytes32\"}],\"name\":\"OrderNotExisting\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"bits\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"SafeCastOverflowedUintDowncast\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"authority\",\"type\":\"address\"}],\"name\":\"AuthorityUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[],\"name\":\"EIP712DomainChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newFeeRecipient\",\"type\":\"address\"}],\"name\":\"FeeRecipientUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"version\",\"type\":\"uint64\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"oldNonce\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"newNonce\",\"type\":\"uint256\"}],\"name\":\"NonceIncreased\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"}],\"name\":\"OrderCanceled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"actualMaking\",\"type\":\"uint256\"}],\"name\":\"OrderFilled\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Paused\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newRouter\",\"type\":\"address\"}],\"name\":\"RouterUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"Unpaused\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint8\",\"name\":\"amount\",\"type\":\"uint8\"}],\"name\":\"advanceNonce\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"authority\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"PT\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"permit\",\"type\":\"bytes\"}],\"internalType\":\"struct ILimitOrderEngine.Order[]\",\"name\":\"orders\",\"type\":\"tuple[]\"}],\"name\":\"cancelBatch\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"PT\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"permit\",\"type\":\"bytes\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"}],\"name\":\"cancelSingle\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"eip712Domain\",\"outputs\":[{\"internalType\":\"bytes1\",\"name\":\"fields\",\"type\":\"bytes1\"},{\"internalType\":\"string\",\"name\":\"name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"version\",\"type\":\"string\"},{\"internalType\":\"uint256\",\"name\":\"chainId\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"verifyingContract\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"salt\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"extensions\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"feeRecipient\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"PT\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"permit\",\"type\":\"bytes\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"}],\"name\":\"hashOrder\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"increaseNonce\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_feeRecipient\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_router\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_initialAuthority\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"isConsumingScheduledOp\",\"outputs\":[{\"internalType\":\"bytes4\",\"name\":\"\",\"type\":\"bytes4\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"nonce\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"makerAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makerNonce\",\"type\":\"uint256\"}],\"name\":\"nonceEquals\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"orderHashes\",\"type\":\"bytes32[]\"}],\"name\":\"orderStatuses\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"remainings\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"filledAmounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"orderHashes\",\"type\":\"bytes32[]\"}],\"name\":\"orderStatusesRaw\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"remainingsRaw\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256[]\",\"name\":\"filledAmounts\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"pause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"paused\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"router\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newAuthority\",\"type\":\"address\"}],\"name\":\"setAuthority\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newFeeRecipient\",\"type\":\"address\"}],\"name\":\"setFeeRecipient\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newRouter\",\"type\":\"address\"}],\"name\":\"setRouter\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"PT\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"permit\",\"type\":\"bytes\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxTaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.FillOrderParams[]\",\"name\":\"params\",\"type\":\"tuple[]\"},{\"components\":[{\"internalType\":\"uint256\",\"name\":\"actualTaking\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"actualMaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.OrderResult[]\",\"name\":\"validatedResults\",\"type\":\"tuple[]\"},{\"internalType\":\"contract IERC20\",\"name\":\"takerToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"totalFees\",\"type\":\"uint256\"}],\"name\":\"transferPostValidation\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"unpause\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"components\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"salt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"expiry\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nonce\",\"type\":\"uint256\"},{\"internalType\":\"enum ILimitOrderEngine.OrderType\",\"name\":\"orderType\",\"type\":\"uint8\"},{\"internalType\":\"address\",\"name\":\"PT\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"maker\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"receiver\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"impliedRate\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"permit\",\"type\":\"bytes\"}],\"internalType\":\"struct ILimitOrderEngine.Order\",\"name\":\"order\",\"type\":\"tuple\"},{\"internalType\":\"bytes\",\"name\":\"signature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"makingAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"maxTaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.FillOrderParams[]\",\"name\":\"params\",\"type\":\"tuple[]\"}],\"name\":\"validateOrdersAndUpdateStatus\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"actualTaking\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"actualMaking\",\"type\":\"uint256\"}],\"internalType\":\"struct ILimitOrderEngine.OrderResult[]\",\"name\":\"validatedResults\",\"type\":\"tuple[]\"},{\"internalType\":\"address\",\"name\":\"takerToken\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"totalTaking\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"totalFees\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"errors\":{\"EnforcedPause()\":[{\"details\":\"The operation failed because the contract is paused.\"}],\"ExpectedPause()\":[{\"details\":\"The operation failed because the contract is not paused.\"}],\"InvalidInitialization()\":[{\"details\":\"The contract is already initialized.\"}],\"NotInitializing()\":[{\"details\":\"The contract is not initializing.\"}],\"SafeCastOverflowedUintDowncast(uint8,uint256)\":[{\"details\":\"Value doesn't fit in an uint of `bits` size.\"}]},\"events\":{\"AuthorityUpdated(address)\":{\"details\":\"Authority that manages this contract was updated.\"},\"EIP712DomainChanged()\":{\"details\":\"MAY be emitted to signal that the domain could have changed.\"},\"Initialized(uint64)\":{\"details\":\"Triggered when the contract has been initialized or reinitialized.\"},\"Paused(address)\":{\"details\":\"Emitted when the pause is triggered by `account`.\"},\"Unpaused(address)\":{\"details\":\"Emitted when the pause is lifted by `account`.\"}},\"kind\":\"dev\",\"methods\":{\"authority()\":{\"details\":\"Returns the current authority.\"},\"cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes)[])\":{\"details\":\"Loops through orders and cancels each one.\",\"params\":{\"orders\":\"Array of orders to cancel.\"}},\"cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))\":{\"details\":\"Sets order status as filled and emits an event.\",\"params\":{\"order\":\"The order to cancel.\"}},\"eip712Domain()\":{\"details\":\"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature.\"},\"hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))\":{\"params\":{\"order\":\"The order to hash\"},\"returns\":{\"_0\":\"The order's hash as bytes32\"}},\"isConsumingScheduledOp()\":{\"details\":\"Returns true only in the context of a delayed restricted call, at the moment that the scheduled operation is being consumed. Prevents denial of service for delayed restricted calls in the case that the contract performs attacker controlled calls.\"},\"nonceEquals(address,uint256)\":{\"returns\":{\"_0\":\"Result True if `makerAddress` has specified nonce. Otherwise, false\"}},\"orderStatuses(bytes32[])\":{\"details\":\"Adjusts raw remaining values by subtracting one to confirm order existence\",\"params\":{\"orderHashes\":\"Array of order hashes to query\"},\"returns\":{\"filledAmounts\":\"Filled amounts for each order\",\"remainings\":\"Processed remaining amounts for each order\"}},\"orderStatusesRaw(bytes32[])\":{\"params\":{\"orderHashes\":\"Array of order hashes to query\"},\"returns\":{\"filledAmounts\":\"Filled amounts for each order\",\"remainingsRaw\":\"Raw remaining amounts for each order\"}},\"paused()\":{\"details\":\"Returns true if the contract is paused, and false otherwise.\"},\"setAuthority(address)\":{\"details\":\"Transfers control to a new authority. The caller must be the current authority.\"},\"transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256)\":{\"params\":{\"params\":\"Order parameters with permits\",\"receiver\":\"Address to receive maker tokens\",\"takerToken\":\"Token being provided by taker\",\"totalFees\":\"Total fees to transfer\",\"validatedResults\":\"Actual amounts to transfer per order\"}},\"validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[])\":{\"details\":\"Performs multiple validation checks on each order including:      - Verifies order expiration hasn't been reached      - Confirms nonce is valid and not already used      - Validates signature authenticity      - Updates remaining fillable amounts for partial fillsMust be called by the authorized router contract onlyAll orders must specify the same taker token (depending on PT and OrderType) or the function will revert\",\"params\":{\"params\":\"Array of FillOrderParams containing order details and fill amounts\"},\"returns\":{\"takerToken\":\"Address of the token being taken from the taker\",\"totalFees\":\"Aggregate amount of fees collected from the transaction\",\"totalTaking\":\"Aggregate amount of takerToken being received from the taker (totalFees is included)\",\"validatedResults\":\"Array of OrderResult structs with validation status and filled amounts\"}}},\"stateVariables\":{\"feeRecipient\":{\"details\":\"This function returns the address that receives protocol fees.\",\"return\":\"The address of the current fee recipient.\",\"returns\":{\"_0\":\"The address of the current fee recipient.\"}},\"router\":{\"details\":\"The router is the only contract that can call `validateOrdersAndUpdateStatus()`.\",\"return\":\"The address of the current router contract.\",\"returns\":{\"_0\":\"The address of the current router contract.\"}}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"advanceNonce(uint8)\":{\"notice\":\"Advances nonce by specified amount\"},\"cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes)[])\":{\"notice\":\"Cancels multiple orders in a batch.\"},\"cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))\":{\"notice\":\"Cancels a single order.\"},\"feeRecipient()\":{\"notice\":\"Retrieves the current fee recipient.\"},\"hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))\":{\"notice\":\"Computes a unique hash for an order\"},\"increaseNonce()\":{\"notice\":\"Advances nonce by one\"},\"nonceEquals(address,uint256)\":{\"notice\":\"Checks if `makerAddress` has specified `makerNonce`\"},\"orderStatuses(bytes32[])\":{\"notice\":\"Gets processed order statuses\"},\"orderStatusesRaw(bytes32[])\":{\"notice\":\"Gets raw remaining and filled amounts for orders\"},\"router()\":{\"notice\":\"Retrieves the current router address.\"},\"transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256)\":{\"notice\":\"Executes token transfers for validated limit orders\"},\"validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[])\":{\"notice\":\"Validates orders, updates their status, and calculates aggregate totals\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/LimitOrderEngine.sol\":\"LimitOrderEngine\"},\"evmVersion\":\"cancun\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[\":@openzeppelin-contracts-5.4.0-rc.1/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/\",\":@openzeppelin-contracts-upgradeable-5.4.0-rc.1/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/\",\":@openzeppelin/contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/\",\":@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/\",\":AMProxy/=dependencies/core-v2-staging/src/proxy/\",\":config/=dependencies/spectra-contracts-configs-main/script/\",\":core-v2-staging/=dependencies/core-v2-staging/\",\":core-v2/=dependencies/core-v2-staging/\",\":ds-test/=dependencies/core-v2-staging/lib/forge-std/lib/ds-test/src/\",\":erc4626-tests/=dependencies/core-v2-staging/lib/openzeppelin-contracts/lib/erc4626-tests/\",\":forge-std-1.9.7/=dependencies/forge-std-1.9.7/src/\",\":forge-std/=dependencies/forge-std-1.9.7/src/\",\":openzeppelin-contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/\",\":openzeppelin-contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/\",\":openzeppelin-erc20-basic/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/\",\":openzeppelin-erc20-extensions/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/token/ERC20/extensions/\",\":openzeppelin-erc20/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/token/ERC20/\",\":openzeppelin-math/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/\",\":openzeppelin-proxy/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/proxy/utils/\",\":openzeppelin-utils/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/\",\":spectra-contracts-configs-main/=dependencies/spectra-contracts-configs-main/\",\":spectra-contracts-configs/=dependencies/core-v2-staging/lib/\",\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/:@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/\",\"dependencies/core-v2-staging:script/=dependencies/core-v2-staging/script/\",\"dependencies/core-v2-staging:src/=dependencies/core-v2-staging/src/\"]},\"sources\":{\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/AccessManaged.sol\":{\"keccak256\":\"0x99c633472387324f902c3c125938a98711d4cb0b077ae3999bb318d7d0435c19\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f39b65e6bc37152819275df8fe01252edf55f118d30d51e4ab9a585d94c1a881\",\"dweb:/ipfs/QmYc7q1Anwgig2JbhLiKyDwU21w4QbY2Sogm7aoad7CLiC\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/AuthorityUtils.sol\":{\"keccak256\":\"0x05fd06ae5bca9dc7470fb2dfae764315c81a84f591e86be6fec0c115474edc6c\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://998ffed150fad3264d73c847f2ca35ee750d747ece382bb48885e8c8dce62941\",\"dweb:/ipfs/QmSjacwVExF2T9ZFysQQ3vVLJbDQ16G7zd81SDxPCfNFxe\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAccessManaged.sol\":{\"keccak256\":\"0x4ad12e231e8b1567e4086b134f5ff59a08cb8b1ea6d8fa9ecceec30b4b28ad89\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://81657c0f105f4c92c1a67bcbc7a6afb6c2a937616b8168a63f3fdff61ea4957f\",\"dweb:/ipfs/QmS3ZBTCr34uuVCXVRfuuvh5QRT9upruNhi222EjJ7tgJp\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAccessManager.sol\":{\"keccak256\":\"0x3a129298f50d5e1e8d46d91eb6aa40e18183b76f6983e13a0a1e5f43a8faedb6\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://e1a20642c110215a14f97d7cbd7048a19db9b9500b020b17b96138406ab6ab07\",\"dweb:/ipfs/QmRbrcJjQzGnz7T6KYCpZYtDYpx6id2KSDis7DPQhye1Zr\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAuthority.sol\":{\"keccak256\":\"0xd7b800fcca190ec8030b5d5792d7b5e6de3213ab322ada322e905540c58edd3b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b0d5da4f1aa7120b6fac945df72ff3661b0d1ee9bc175023ec29cecc6324c76b\",\"dweb:/ipfs/QmPDSsk9WcVwx4Je1t59txPUzh7si4Hnhu11VPjrTwQFPL\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1271.sol\":{\"keccak256\":\"0x67ddf13274cfd1dd994552801d8e2f67a32e2301d6680d7bb2eda99a7feff5eb\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://137e025f914ff2d56889b68629337b5f4dc4cba181cd0a3ec42a2e0cdf1d396a\",\"dweb:/ipfs/QmaVBNddWRuukyYZKAKDsvDZ64JWGCiMmF95cktsfH9muM\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1363.sol\":{\"keccak256\":\"0xcef3dfbf36b24b3d0bd209f8e1869f4c86287878240f66e651b122d26448fcc3\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ebc799e73eaf8a32c7be984f422f5b237e4b36277251968c60f74b282ecd1c91\",\"dweb:/ipfs/QmczzYkjSv93ZtPswneWbYSjkd4LEbhkg8iB4ZATvCEfCz\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC165.sol\":{\"keccak256\":\"0x71f27f20e8998b0d0266a5b5a9a73346baf513c98f7fe941d13f293c6f5f30fa\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8a810b05b2727a18024c91842beb4a65c6785d477c931a0e679fedba4963f73c\",\"dweb:/ipfs/QmdWk9H4YuKU9M86VsZD1syn4SMbVJCvoRGRwn74gLPRLG\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1967.sol\":{\"keccak256\":\"0x23353583409a0aa27f089fa1418033ea755d19843eb8337b58aeda2e9764a127\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://705a41ec0e37e0e8625ac41671c292ff34c7039f133a4bb2121a658a1b88eb08\",\"dweb:/ipfs/QmaQJwHqRFNnmnexuV8yJjKjzfHGi34MWm4MEhPu2teiJY\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC20.sol\":{\"keccak256\":\"0x742c788bf2723742350a299027925399eb5b1da6b4971af846aabe742f7ce9fa\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://3a001c31d79f8df22a8b8111c728ab6719c516391e7687a16648c84242c3641b\",\"dweb:/ipfs/QmT7uM2J8pPKUjJJzVNYQiswd4eG6AU1CWDecCWdHrm3oz\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC20Metadata.sol\":{\"keccak256\":\"0x877f2cab8e4dfa6174d0177f04181319da118a7e367493ad7c68ee4cb8be7205\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c368c7a1eec4c3a6ae815e775f9bdbdd0130ad0c0b09447e9b9d56a2a4cafe2f\",\"dweb:/ipfs/QmbbMtEf5ZY6ZpQKLsVvmsHLB7A639qnEiAqhjSP3k17tY\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC3156FlashBorrower.sol\":{\"keccak256\":\"0xd470da87c982da3f6be8555b63f10d66462054def9d7da20aae37c3ee3c96d58\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c76692163f771760363ff3001755a6e1331c0b25b23ddaf5e072c0ed67f4b5cc\",\"dweb:/ipfs/QmXhYb6dwmoGq1ZcGfbuC5RaYFaDLG3FdqhHC4GqNe75DP\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC3156FlashLender.sol\":{\"keccak256\":\"0xbf67f5abbdb40a69d887f34bb9c578945c4d80ea5566264a16165bf49d06665b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6e325477bf279e74e4c4d13d5014a60697f35d20134ce424970f2336a7740423\",\"dweb:/ipfs/QmVrthF7KY6kp2RXrfiCZk9uZwPYHdPCqgiPpDeShJWu3z\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC4626.sol\":{\"keccak256\":\"0x085fcdfdf42d0092040e702303f54f9a0a3540bf25921588f0c44f2a870485df\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://cb8e63b28c91aaa8c5c6e393c39d53ced9868128ce60f8a0d38d57f7eebfa59f\",\"dweb:/ipfs/QmNfU4XSGnv8eD5UREt7Rs5TiLT2iVGd2CWpka3brngmRT\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC5267.sol\":{\"keccak256\":\"0x473d635a93adf200d4ec9ef1cb3ba9d33230d546fa0eb8ab95e6ed5a461da5d9\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://28dd2f7722f144efa18ad2797c744d214e02495f948d4d73b354ef049a6f813f\",\"dweb:/ipfs/QmeSyAoJk1FuS6F7MzJj6dvnqd6jNz6pNP2WjjLPhDLHdg\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC7913.sol\":{\"keccak256\":\"0xfa287c745741ef58af71e1068ebf9771fe55bc17c9efe39517d942a005744f24\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://78a7f7ab52e2ea38fb0f79ad786bb575af5e6a60a44a31bef37fbdeffd88330f\",\"dweb:/ipfs/QmZSiVgsapHHmQspCYDVGjayZANcvct4m2i65QdC2N3VGU\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/proxy/ERC1967/ERC1967Proxy.sol\":{\"keccak256\":\"0xa3066ff86b94128a9d3956a63a0511fa1aae41bd455772ab587b32ff322acb2e\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://bf7b192fd82acf6187970c80548f624b1b9c80425b62fa49e7fdb538a52de049\",\"dweb:/ipfs/QmWXG1YCde1tqDYTbNwjkZDWVgPEjzaQGSDqWkyKLzaNua\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/proxy/ERC1967/ERC1967Utils.sol\":{\"keccak256\":\"0x0f42d3c4b0cc63a53bea0cbdc22cad383a741ba0e15e7009daf337c056ed4efb\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1c481c794adcbf16967b04998a95db13d50f1409f1b99d938334833645b62fe8\",\"dweb:/ipfs/QmapU5kJur7GQ6CQseP2bEAYqPKFGHJAhcsSz4QgNrVase\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/proxy/Proxy.sol\":{\"keccak256\":\"0xc3f2ec76a3de8ed7a7007c46166f5550c72c7709e3fc7e8bb3111a7191cdedbd\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://e73efb4c2ca655882dc237c6b4f234a9bd36d97159d8fcaa837eb01171f726ac\",\"dweb:/ipfs/QmTNnnv7Gu5fs5G1ZMh7Fexp8N4XUs3XrNAngjcxgiss3e\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/proxy/beacon/IBeacon.sol\":{\"keccak256\":\"0x8e23a5e06f7fc9df2ae25396f8f0f8c8901f9a66a10a1e03f3138a04a69db7bc\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://fa2c8656590fac2915bb5ff3416efd4d51774d34ea5ec1ca20566df7ead51295\",\"dweb:/ipfs/QmXxPTA1U7YUHhVfJPRe6UxcADu4T1C9673u1u3hiQjKJS\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/IERC20.sol\":{\"keccak256\":\"0xaa5c002dccc71cf9d6dd92a9fa87f205f32b0b9204303c442d567bfcb832d69d\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f17355804cadb61737c6d7ebf9539cd27eacd8a9099ffe711ce9dc0a2dd07442\",\"dweb:/ipfs/QmSVBcaVaaC9SxVsYsmfY1U3du3inqbNGPEpcMY4KkRrrj\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/extensions/IERC20Metadata.sol\":{\"keccak256\":\"0x090e3e7ffd747b5546cb7033e5425ec7fc8813da81f8bee455318fd8af5cc3a0\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://423facd62c0103f6810c7b43c1cf3002e8728a9e3aa57c32c46d100137a6f2ae\",\"dweb:/ipfs/QmPcMF3srsURFQRpQNCC5ALv8eGVFeupK8TYirBNTWVC8b\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/extensions/IERC20Permit.sol\":{\"keccak256\":\"0xa20fb0cd8147050fa1bcd21d76baf4b696879be5cc52f91bd3261dfd1b4acd2f\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://0df62ff0cc45ad15d2b2d3a99842c45a2f9ad6fc99ce56112e36bd2da417d229\",\"dweb:/ipfs/QmYxvt5E1PhvTJXskBWU6Y1N56dT6gzzTUDSKXmmKSWHkQ\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/utils/SafeERC20.sol\":{\"keccak256\":\"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8150ceb4ac947e8a442b2a9c017e01e880b2be2dd958f1fa9bc405f4c5a86508\",\"dweb:/ipfs/QmbcBmFX66AY6Kbhnd5gx7zpkgqnUafo43XnmayAM7zVdB\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Address.sol\":{\"keccak256\":\"0xf17347b68bf7a199ebb71c8ee074edf31c9302f26013050d7f28f88360fab83a\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://44fb441daade9ca80695f2bec4f118eee3a307ded5de4597e552d9e6a7b43bba\",\"dweb:/ipfs/Qmc6VR5eTSiv3P2cF4tENXDH9JNcErFFzQzY21wZPrgzfH\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Bytes.sol\":{\"keccak256\":\"0xee79e30c45319d56e7536317e1776686ec2d475795a27c3f2ac7e9c2f4edef7f\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://d0952f3c09421d8b2b3896b4789ad655a114b9206365b5363c1dd0a75583997d\",\"dweb:/ipfs/QmQPemDMHjWhhLmazue7gHnZRYxcbz9nbz4pKcC7ioSFyz\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Context.sol\":{\"keccak256\":\"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6a708e8a5bdb1011c2c381c9a5cfd8a9a956d7d0a9dc1bd8bcdaf52f76ef2f12\",\"dweb:/ipfs/Qmax9WHBnVsZP46ZxEMNRQpLQnrdE4dK8LehML1Py8FowF\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Errors.sol\":{\"keccak256\":\"0x6afa713bfd42cf0f7656efa91201007ac465e42049d7de1d50753a373648c123\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ba1d02f4847670a1b83dec9f7d37f0b0418d6043447b69f3a29a5f9efc547fcf\",\"dweb:/ipfs/QmQ7iH2keLNUKgq2xSWcRmuBE5eZ3F5whYAkAGzCNNoEWB\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Panic.sol\":{\"keccak256\":\"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://c6a5ff4f9fd8649b7ee20800b7fa387d3465bd77cf20c2d1068cd5c98e1ed57a\",\"dweb:/ipfs/QmVSaVJf9FXFhdYEYeCEfjMVHrxDh5qL4CGkxdMWpQCrqG\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/StorageSlot.sol\":{\"keccak256\":\"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://9f660b1f351b757dfe01438e59888f31f33ded3afcf5cb5b0d9bf9aa6f320a8b\",\"dweb:/ipfs/QmarDJ5hZEgBtCmmrVzEZWjub9769eD686jmzb2XpSU1cM\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Strings.sol\":{\"keccak256\":\"0x72d89c30d5c7c7f7923677b3738ceffe5a5671f885b4637badd0084c3f438213\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://15ad622659ea59783478bc73db26d57a74f400aef716a6478613919e45bd4b71\",\"dweb:/ipfs/QmPcaMREGhoehgMhY9s6BUrsVoK7F6YNU1xkG4VFe5yXjT\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/ECDSA.sol\":{\"keccak256\":\"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8e25e4bdb7ae1f21d23bfee996e22736fc0ab44cfabedac82a757b1edc5623b9\",\"dweb:/ipfs/QmQdWQvB6JCP9ZMbzi8EvQ1PTETqkcTWrbcVurS7DKpa5n\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/MessageHashUtils.sol\":{\"keccak256\":\"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b16d45febff462bafd8a5669f904796a835baf607df58a8461916d3bf4f08c59\",\"dweb:/ipfs/QmU2eJFpjmT4vxeJWJyLeQb8Xht1kdB8Y6MKLDPFA9WPux\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/SignatureChecker.sol\":{\"keccak256\":\"0x60da29c52e83ab33d9335cd153b7ef333d1758731eb5a600d13228a5ea30a704\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://f9d21b7b68fc9b5406d8e762aaef2d4f3d06de774b37486555404919394a6b35\",\"dweb:/ipfs/QmQZYwwhyZyYfmcKKeLm6g7CBb8tF42XUVXE9mvywLnUJQ\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/introspection/IERC165.sol\":{\"keccak256\":\"0x2820b23a27421cbb9be0239e2210efbcdb73c3224e1a48acb7daff8d7d26964f\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://a00d4c01544a03232adb233c3e82d1b1eb82bde78df17f05fd56232f2773bd23\",\"dweb:/ipfs/QmZ9tPFfYYMdc3PCJPcAWCdvJ3Gt646MJxk2RZ3D9tjeZN\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/Math.sol\":{\"keccak256\":\"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6c5fab4970634f9ab9a620983dc1c8a30153981a0b1a521666e269d0a11399d3\",\"dweb:/ipfs/QmVRnBC575MESGkEHndjujtR7qub2FzU9RWy9eKLp4hPZB\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/SafeCast.sol\":{\"keccak256\":\"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://b1d578337048cad08c1c03041cca5978eff5428aa130c781b271ad9e5566e1f8\",\"dweb:/ipfs/QmPFKL2r9CBsMwmUqqdcFPfHZB2qcs9g1HDrPxzWSxomvy\"]},\"dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/SignedMath.sol\":{\"keccak256\":\"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://db5fbb3dddd8b7047465b62575d96231ba8a2774d37fb4737fbf23340fabbb03\",\"dweb:/ipfs/QmVUSvooZKEdEdap619tcJjTLcAuH6QBdZqAzWwnAXZAWJ\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/access/manager/AccessManagedUpgradeable.sol\":{\"keccak256\":\"0xafc6430a5a632a57bf0e1596dccdad8f208f449cfc340878dc1789e5f5b570d5\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1935bb38eac62a468fdc3f00174e4cb28b476668895ddfea5e0bcf56297b8145\",\"dweb:/ipfs/QmVmSMB2tykT9t5ZoMkREn2zNzYtK2ufNdxRYo3B7MLvVT\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/proxy/utils/Initializable.sol\":{\"keccak256\":\"0xdb4d24ee2c087c391d587cd17adfe5b3f9d93b3110b1388c2ab6c7c0ad1dcd05\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://ab7b6d5b9e2b88176312967fe0f0e78f3d9a1422fa5e4b64e2440c35869b5d08\",\"dweb:/ipfs/QmXKYWWyzcLg1B2k7Sb1qkEXgLCYfXecR9wYW5obRzWP1Q\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/ContextUpgradeable.sol\":{\"keccak256\":\"0xdbef5f0c787055227243a7318ef74c8a5a1108ca3a07f2b3a00ef67769e1e397\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://08e39f23d5b4692f9a40803e53a8156b72b4c1f9902a88cd65ba964db103dab9\",\"dweb:/ipfs/QmPKn6EYDgpga7KtpkA8wV2yJCYGMtc9K4LkJfhKX2RVSV\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/PausableUpgradeable.sol\":{\"keccak256\":\"0xa6bf6b7efe0e6625a9dcd30c5ddf52c4c24fe8372f37c7de9dbf5034746768d5\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8c353ee3705bbf6fadb84c0fb10ef1b736e8ca3ca1867814349d1487ed207beb\",\"dweb:/ipfs/QmcugaPssrzGGE8q4YZKm2ZhnD3kCijjcgdWWg76nWt3FY\"]},\"dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/cryptography/EIP712Upgradeable.sol\":{\"keccak256\":\"0xba34a957324b4b1cb867111b948afc0cda72f5e9fdc7cb9b9b7bfeb0c2ad4edb\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://214590a0ca86c1209ef46f240c06ea1b9eb64e55bc98c2e3efc470fb682002f0\",\"dweb:/ipfs/Qme7wm5XTn8U3Xmn35DtpXw817888Drjm9YhJP2vQAunqV\"]},\"dependencies/core-v2-staging/src/interfaces/IPrincipalToken.sol\":{\"keccak256\":\"0x8fb04690eb8cca9c4e9c68ac7991837ff4a383c2c27869259c3b3553aeaa32b8\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://5f6c1d66a951054e59b93e84f9de6af9abd584a46aad1bb558bdc338c6715abc\",\"dweb:/ipfs/QmZyAggpy2U82hgZsq3Ri3GMNDDi2tGD62s1USGxqoZTa1\"]},\"dependencies/core-v2-staging/src/interfaces/IRegistry.sol\":{\"keccak256\":\"0x404a0ff1e75d1db0f3432718c66b49e6ca4df8f1df4573fb93c1c143475793df\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://6812a64f888dcd38573f3c8daca5b88404c2bc7a107b79af281ede6f5119063d\",\"dweb:/ipfs/QmPDKUG6bspqPzSWvK2AM1RLemBpSGhY3ZtR7aASsgXAJb\"]},\"dependencies/core-v2-staging/src/libraries/LogExpMath.sol\":{\"keccak256\":\"0x83fa012405dacb88992aa6653d8cf1fe6a00def6abd09e715c79f7a5a5a8fe74\",\"license\":\"GPL-3.0-or-later\",\"urls\":[\"bzz-raw://355bc2a9afcc3a44a90223ab6f42cbdf71722d7ab145ce429c5406052530fba5\",\"dweb:/ipfs/QmUSPm8tkEJ275eLQ7MP9AWcxs1BMtyreeZyFGK1eD9GEL\"]},\"dependencies/core-v2-staging/src/libraries/RayMath.sol\":{\"keccak256\":\"0xeb628b5cf03604856852b140401593daefc51cde6b426f2bccb7b21a4a6f3bff\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://0d0eb1f485646176a868b379fd445c06ce97d9ed78809660428484dbca8f943e\",\"dweb:/ipfs/QmWHgYkWbwRACsfhriTwRv3sp1BZ28UobXSHWfQ62WouY7\"]},\"dependencies/core-v2-staging/src/proxy/AMProxyAdmin.sol\":{\"keccak256\":\"0xb83d5d3a362a363288da8180275ac79043cacf4bf1f33065794fdd7c518265aa\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://8ff95e79befdd80d253e5fae71663c4b8e93f03b84735ead60dfcd1da671471f\",\"dweb:/ipfs/QmabMVizi6iVKqscnpCybaAW7tshFunPfPsZ42cEADgsa8\"]},\"dependencies/core-v2-staging/src/proxy/AMTransparentUpgradeableProxy.sol\":{\"keccak256\":\"0xc90c7d52baac84ec544e8e6a6027118e3135b7630fef6eeac344c34812777ee3\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://e7000d4e3057705801232342ae90b235af2a217b3c8d369b682ee01950cae2d8\",\"dweb:/ipfs/QmXxX1HXHhC1YFE7YkLEvjDzr8rFPLyyeKqiuPFTpdsw9v\"]},\"src/LimitOrderEngine.sol\":{\"keccak256\":\"0x2258531cefbe6483092dec46a53a7db7174c8ff86c257ca10565589e19b00c95\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://244e848af2250318b669238a4ab5aba1e5c2fc873d87f34a82f382b9fbffa400\",\"dweb:/ipfs/QmdKCBrnkSka3w8DZwrxVNf35oCUL9nXWZ3BmzhMvaaFWm\"]},\"src/NonceManager.sol\":{\"keccak256\":\"0x7b02825144810dea809676e788b2bd41f825be4e1aa9cc63618d5b84147b66bd\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://48132b3808d45cad91be335f2c876b1d07160cce8b3ac60d575d63e3d7849f7e\",\"dweb:/ipfs/QmQKNXVYWh5Wi2rBhrWo7Q6PtikCf5no1ap2CwXzweUVDj\"]},\"src/interfaces/ILimitOrderEngine.sol\":{\"keccak256\":\"0x453f83a46c8814560b2c77f9a8bfc4e263f90832ccb00a4f197323037974fb25\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://37b40432ce524a0ab905c24361c9b586d526b34471e2197151966ac25e036c4b\",\"dweb:/ipfs/QmXxq2yGz6kfXgPzs9YueXW7Ens2PpMREkXyQ8SdgpyWrs\"]},\"src/interfaces/IRegistryGetter.sol\":{\"keccak256\":\"0x9414228123d5d22c89b08f274d74065dbe1f1cd3f2e2df042c041bb0921515eb\",\"license\":\"BUSL-1.1\",\"urls\":[\"bzz-raw://c5f194979aed56474e7586e632fc9c8460074f291a300199673bf5f78e36c16f\",\"dweb:/ipfs/QmVrzqmXHuP8B4SduhWApYeHXdnMNVwHYUw4pTF4HbGhZd\"]}},\"version\":1}",
-   "metadata":{
-      "compiler":{
-         "version":"0.8.24+commit.e11b9ed9"
-      },
-      "language":"Solidity",
-      "output":{
-         "abi":[
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"nonpayable",
-               "type":"constructor"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"authority",
-                     "type":"address"
-                  }
-               ],
-               "type":"error",
-               "name":"AccessManagedInvalidAuthority"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"caller",
-                     "type":"address"
-                  },
-                  {
-                     "internalType":"uint32",
-                     "name":"delay",
-                     "type":"uint32"
-                  }
-               ],
-               "type":"error",
-               "name":"AccessManagedRequiredDelay"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"caller",
-                     "type":"address"
-                  }
-               ],
-               "type":"error",
-               "name":"AccessManagedUnauthorized"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"bytes32",
-                     "name":"orderId",
-                     "type":"bytes32"
-                  }
-               ],
-               "type":"error",
-               "name":"AlreadyFilled"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"EnforcedPause"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"ExpectedPause"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"IncompatibleOrderBatch"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"InvalidInitialization"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"InvalidOrderType"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"MaxTakingExceeded"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"NoValidOrder"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"NotInitializing"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"NotMaker"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"error",
-               "name":"NotRouter"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"bytes32",
-                     "name":"orderId",
-                     "type":"bytes32"
-                  }
-               ],
-               "type":"error",
-               "name":"OrderNotExisting"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"uint8",
-                     "name":"bits",
-                     "type":"uint8"
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"value",
-                     "type":"uint256"
-                  }
-               ],
-               "type":"error",
-               "name":"SafeCastOverflowedUintDowncast"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"authority",
-                     "type":"address",
-                     "indexed":false
-                  }
-               ],
-               "type":"event",
-               "name":"AuthorityUpdated",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "type":"event",
-               "name":"EIP712DomainChanged",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"newFeeRecipient",
-                     "type":"address",
-                     "indexed":true
-                  }
-               ],
-               "type":"event",
-               "name":"FeeRecipientUpdated",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"uint64",
-                     "name":"version",
-                     "type":"uint64",
-                     "indexed":false
-                  }
-               ],
-               "type":"event",
-               "name":"Initialized",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"maker",
-                     "type":"address",
-                     "indexed":true
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"oldNonce",
-                     "type":"uint256",
-                     "indexed":false
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"newNonce",
-                     "type":"uint256",
-                     "indexed":false
-                  }
-               ],
-               "type":"event",
-               "name":"NonceIncreased",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"maker",
-                     "type":"address",
-                     "indexed":false
-                  },
-                  {
-                     "internalType":"bytes32",
-                     "name":"orderHash",
-                     "type":"bytes32",
-                     "indexed":false
-                  }
-               ],
-               "type":"event",
-               "name":"OrderCanceled",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"bytes32",
-                     "name":"orderHash",
-                     "type":"bytes32",
-                     "indexed":false
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"actualMaking",
-                     "type":"uint256",
-                     "indexed":false
-                  }
-               ],
-               "type":"event",
-               "name":"OrderFilled",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"account",
-                     "type":"address",
-                     "indexed":false
-                  }
-               ],
-               "type":"event",
-               "name":"Paused",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"newRouter",
-                     "type":"address",
-                     "indexed":true
-                  }
-               ],
-               "type":"event",
-               "name":"RouterUpdated",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"account",
-                     "type":"address",
-                     "indexed":false
-                  }
-               ],
-               "type":"event",
-               "name":"Unpaused",
-               "anonymous":false
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"uint8",
-                     "name":"amount",
-                     "type":"uint8"
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"advanceNonce"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"authority",
-               "outputs":[
-                  {
-                     "internalType":"address",
-                     "name":"",
-                     "type":"address"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"struct ILimitOrderEngine.Order[]",
-                     "name":"orders",
-                     "type":"tuple[]",
-                     "components":[
-                        {
-                           "internalType":"uint256",
-                           "name":"salt",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"expiry",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"nonce",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"enum ILimitOrderEngine.OrderType",
-                           "name":"orderType",
-                           "type":"uint8"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"PT",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"maker",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"receiver",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"makingAmount",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"impliedRate",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"bytes",
-                           "name":"permit",
-                           "type":"bytes"
-                        }
-                     ]
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"cancelBatch"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"struct ILimitOrderEngine.Order",
-                     "name":"order",
-                     "type":"tuple",
-                     "components":[
-                        {
-                           "internalType":"uint256",
-                           "name":"salt",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"expiry",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"nonce",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"enum ILimitOrderEngine.OrderType",
-                           "name":"orderType",
-                           "type":"uint8"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"PT",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"maker",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"receiver",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"makingAmount",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"impliedRate",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"bytes",
-                           "name":"permit",
-                           "type":"bytes"
-                        }
-                     ]
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"cancelSingle"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"eip712Domain",
-               "outputs":[
-                  {
-                     "internalType":"bytes1",
-                     "name":"fields",
-                     "type":"bytes1"
-                  },
-                  {
-                     "internalType":"string",
-                     "name":"name",
-                     "type":"string"
-                  },
-                  {
-                     "internalType":"string",
-                     "name":"version",
-                     "type":"string"
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"chainId",
-                     "type":"uint256"
-                  },
-                  {
-                     "internalType":"address",
-                     "name":"verifyingContract",
-                     "type":"address"
-                  },
-                  {
-                     "internalType":"bytes32",
-                     "name":"salt",
-                     "type":"bytes32"
-                  },
-                  {
-                     "internalType":"uint256[]",
-                     "name":"extensions",
-                     "type":"uint256[]"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"feeRecipient",
-               "outputs":[
-                  {
-                     "internalType":"address",
-                     "name":"",
-                     "type":"address"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"struct ILimitOrderEngine.Order",
-                     "name":"order",
-                     "type":"tuple",
-                     "components":[
-                        {
-                           "internalType":"uint256",
-                           "name":"salt",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"expiry",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"nonce",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"enum ILimitOrderEngine.OrderType",
-                           "name":"orderType",
-                           "type":"uint8"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"PT",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"maker",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"address",
-                           "name":"receiver",
-                           "type":"address"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"makingAmount",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"impliedRate",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"bytes",
-                           "name":"permit",
-                           "type":"bytes"
-                        }
-                     ]
-                  }
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"hashOrder",
-               "outputs":[
-                  {
-                     "internalType":"bytes32",
-                     "name":"",
-                     "type":"bytes32"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"increaseNonce"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"_feeRecipient",
-                     "type":"address"
-                  },
-                  {
-                     "internalType":"address",
-                     "name":"_router",
-                     "type":"address"
-                  },
-                  {
-                     "internalType":"address",
-                     "name":"_initialAuthority",
-                     "type":"address"
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"initialize"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"isConsumingScheduledOp",
-               "outputs":[
-                  {
-                     "internalType":"bytes4",
-                     "name":"",
-                     "type":"bytes4"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"",
-                     "type":"address"
-                  }
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"nonce",
-               "outputs":[
-                  {
-                     "internalType":"uint256",
-                     "name":"",
-                     "type":"uint256"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"makerAddress",
-                     "type":"address"
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"makerNonce",
-                     "type":"uint256"
-                  }
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"nonceEquals",
-               "outputs":[
-                  {
-                     "internalType":"bool",
-                     "name":"",
-                     "type":"bool"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"bytes32[]",
-                     "name":"orderHashes",
-                     "type":"bytes32[]"
-                  }
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"orderStatuses",
-               "outputs":[
-                  {
-                     "internalType":"uint256[]",
-                     "name":"remainings",
-                     "type":"uint256[]"
-                  },
-                  {
-                     "internalType":"uint256[]",
-                     "name":"filledAmounts",
-                     "type":"uint256[]"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"bytes32[]",
-                     "name":"orderHashes",
-                     "type":"bytes32[]"
-                  }
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"orderStatusesRaw",
-               "outputs":[
-                  {
-                     "internalType":"uint256[]",
-                     "name":"remainingsRaw",
-                     "type":"uint256[]"
-                  },
-                  {
-                     "internalType":"uint256[]",
-                     "name":"filledAmounts",
-                     "type":"uint256[]"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"pause"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"paused",
-               "outputs":[
-                  {
-                     "internalType":"bool",
-                     "name":"",
-                     "type":"bool"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"view",
-               "type":"function",
-               "name":"router",
-               "outputs":[
-                  {
-                     "internalType":"address",
-                     "name":"",
-                     "type":"address"
-                  }
-               ]
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"newAuthority",
-                     "type":"address"
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"setAuthority"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"newFeeRecipient",
-                     "type":"address"
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"setFeeRecipient"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"newRouter",
-                     "type":"address"
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"setRouter"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"address",
-                     "name":"receiver",
-                     "type":"address"
-                  },
-                  {
-                     "internalType":"struct ILimitOrderEngine.FillOrderParams[]",
-                     "name":"params",
-                     "type":"tuple[]",
-                     "components":[
-                        {
-                           "internalType":"struct ILimitOrderEngine.Order",
-                           "name":"order",
-                           "type":"tuple",
-                           "components":[
-                              {
-                                 "internalType":"uint256",
-                                 "name":"salt",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"uint256",
-                                 "name":"expiry",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"uint256",
-                                 "name":"nonce",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"enum ILimitOrderEngine.OrderType",
-                                 "name":"orderType",
-                                 "type":"uint8"
-                              },
-                              {
-                                 "internalType":"address",
-                                 "name":"PT",
-                                 "type":"address"
-                              },
-                              {
-                                 "internalType":"address",
-                                 "name":"maker",
-                                 "type":"address"
-                              },
-                              {
-                                 "internalType":"address",
-                                 "name":"receiver",
-                                 "type":"address"
-                              },
-                              {
-                                 "internalType":"uint256",
-                                 "name":"makingAmount",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"uint256",
-                                 "name":"impliedRate",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"bytes",
-                                 "name":"permit",
-                                 "type":"bytes"
-                              }
-                           ]
-                        },
-                        {
-                           "internalType":"bytes",
-                           "name":"signature",
-                           "type":"bytes"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"makingAmount",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"maxTaking",
-                           "type":"uint256"
-                        }
-                     ]
-                  },
-                  {
-                     "internalType":"struct ILimitOrderEngine.OrderResult[]",
-                     "name":"validatedResults",
-                     "type":"tuple[]",
-                     "components":[
-                        {
-                           "internalType":"uint256",
-                           "name":"actualTaking",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"actualMaking",
-                           "type":"uint256"
-                        }
-                     ]
-                  },
-                  {
-                     "internalType":"contract IERC20",
-                     "name":"takerToken",
-                     "type":"address"
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"totalFees",
-                     "type":"uint256"
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"transferPostValidation"
-            },
-            {
-               "inputs":[
-                  
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"unpause"
-            },
-            {
-               "inputs":[
-                  {
-                     "internalType":"struct ILimitOrderEngine.FillOrderParams[]",
-                     "name":"params",
-                     "type":"tuple[]",
-                     "components":[
-                        {
-                           "internalType":"struct ILimitOrderEngine.Order",
-                           "name":"order",
-                           "type":"tuple",
-                           "components":[
-                              {
-                                 "internalType":"uint256",
-                                 "name":"salt",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"uint256",
-                                 "name":"expiry",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"uint256",
-                                 "name":"nonce",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"enum ILimitOrderEngine.OrderType",
-                                 "name":"orderType",
-                                 "type":"uint8"
-                              },
-                              {
-                                 "internalType":"address",
-                                 "name":"PT",
-                                 "type":"address"
-                              },
-                              {
-                                 "internalType":"address",
-                                 "name":"maker",
-                                 "type":"address"
-                              },
-                              {
-                                 "internalType":"address",
-                                 "name":"receiver",
-                                 "type":"address"
-                              },
-                              {
-                                 "internalType":"uint256",
-                                 "name":"makingAmount",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"uint256",
-                                 "name":"impliedRate",
-                                 "type":"uint256"
-                              },
-                              {
-                                 "internalType":"bytes",
-                                 "name":"permit",
-                                 "type":"bytes"
-                              }
-                           ]
-                        },
-                        {
-                           "internalType":"bytes",
-                           "name":"signature",
-                           "type":"bytes"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"makingAmount",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"maxTaking",
-                           "type":"uint256"
-                        }
-                     ]
-                  }
-               ],
-               "stateMutability":"nonpayable",
-               "type":"function",
-               "name":"validateOrdersAndUpdateStatus",
-               "outputs":[
-                  {
-                     "internalType":"struct ILimitOrderEngine.OrderResult[]",
-                     "name":"validatedResults",
-                     "type":"tuple[]",
-                     "components":[
-                        {
-                           "internalType":"uint256",
-                           "name":"actualTaking",
-                           "type":"uint256"
-                        },
-                        {
-                           "internalType":"uint256",
-                           "name":"actualMaking",
-                           "type":"uint256"
-                        }
-                     ]
-                  },
-                  {
-                     "internalType":"address",
-                     "name":"takerToken",
-                     "type":"address"
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"totalTaking",
-                     "type":"uint256"
-                  },
-                  {
-                     "internalType":"uint256",
-                     "name":"totalFees",
-                     "type":"uint256"
-                  }
-               ]
-            }
-         ],
-         "devdoc":{
-            "kind":"dev",
-            "methods":{
-               "authority()":{
-                  "details":"Returns the current authority."
-               },
-               "cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes)[])":{
-                  "details":"Loops through orders and cancels each one.",
-                  "params":{
-                     "orders":"Array of orders to cancel."
-                  }
-               },
-               "cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))":{
-                  "details":"Sets order status as filled and emits an event.",
-                  "params":{
-                     "order":"The order to cancel."
-                  }
-               },
-               "eip712Domain()":{
-                  "details":"returns the fields and values that describe the domain separator used by this contract for EIP-712 signature."
-               },
-               "hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))":{
-                  "params":{
-                     "order":"The order to hash"
-                  },
-                  "returns":{
-                     "_0":"The order's hash as bytes32"
-                  }
-               },
-               "isConsumingScheduledOp()":{
-                  "details":"Returns true only in the context of a delayed restricted call, at the moment that the scheduled operation is being consumed. Prevents denial of service for delayed restricted calls in the case that the contract performs attacker controlled calls."
-               },
-               "nonceEquals(address,uint256)":{
-                  "returns":{
-                     "_0":"Result True if `makerAddress` has specified nonce. Otherwise, false"
-                  }
-               },
-               "orderStatuses(bytes32[])":{
-                  "details":"Adjusts raw remaining values by subtracting one to confirm order existence",
-                  "params":{
-                     "orderHashes":"Array of order hashes to query"
-                  },
-                  "returns":{
-                     "filledAmounts":"Filled amounts for each order",
-                     "remainings":"Processed remaining amounts for each order"
-                  }
-               },
-               "orderStatusesRaw(bytes32[])":{
-                  "params":{
-                     "orderHashes":"Array of order hashes to query"
-                  },
-                  "returns":{
-                     "filledAmounts":"Filled amounts for each order",
-                     "remainingsRaw":"Raw remaining amounts for each order"
-                  }
-               },
-               "paused()":{
-                  "details":"Returns true if the contract is paused, and false otherwise."
-               },
-               "setAuthority(address)":{
-                  "details":"Transfers control to a new authority. The caller must be the current authority."
-               },
-               "transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256)":{
-                  "params":{
-                     "params":"Order parameters with permits",
-                     "receiver":"Address to receive maker tokens",
-                     "takerToken":"Token being provided by taker",
-                     "totalFees":"Total fees to transfer",
-                     "validatedResults":"Actual amounts to transfer per order"
-                  }
-               },
-               "validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[])":{
-                  "details":"Performs multiple validation checks on each order including:      - Verifies order expiration hasn't been reached      - Confirms nonce is valid and not already used      - Validates signature authenticity      - Updates remaining fillable amounts for partial fillsMust be called by the authorized router contract onlyAll orders must specify the same taker token (depending on PT and OrderType) or the function will revert",
-                  "params":{
-                     "params":"Array of FillOrderParams containing order details and fill amounts"
-                  },
-                  "returns":{
-                     "takerToken":"Address of the token being taken from the taker",
-                     "totalFees":"Aggregate amount of fees collected from the transaction",
-                     "totalTaking":"Aggregate amount of takerToken being received from the taker (totalFees is included)",
-                     "validatedResults":"Array of OrderResult structs with validation status and filled amounts"
-                  }
-               }
-            },
-            "version":1
-         },
-         "userdoc":{
-            "kind":"user",
-            "methods":{
-               "advanceNonce(uint8)":{
-                  "notice":"Advances nonce by specified amount"
-               },
-               "cancelBatch((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes)[])":{
-                  "notice":"Cancels multiple orders in a batch."
-               },
-               "cancelSingle((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))":{
-                  "notice":"Cancels a single order."
-               },
-               "feeRecipient()":{
-                  "notice":"Retrieves the current fee recipient."
-               },
-               "hashOrder((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes))":{
-                  "notice":"Computes a unique hash for an order"
-               },
-               "increaseNonce()":{
-                  "notice":"Advances nonce by one"
-               },
-               "nonceEquals(address,uint256)":{
-                  "notice":"Checks if `makerAddress` has specified `makerNonce`"
-               },
-               "orderStatuses(bytes32[])":{
-                  "notice":"Gets processed order statuses"
-               },
-               "orderStatusesRaw(bytes32[])":{
-                  "notice":"Gets raw remaining and filled amounts for orders"
-               },
-               "router()":{
-                  "notice":"Retrieves the current router address."
-               },
-               "transferPostValidation(address,((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[],(uint256,uint256)[],address,uint256)":{
-                  "notice":"Executes token transfers for validated limit orders"
-               },
-               "validateOrdersAndUpdateStatus(((uint256,uint256,uint256,uint8,address,address,address,uint256,uint256,bytes),bytes,uint256,uint256)[])":{
-                  "notice":"Validates orders, updates their status, and calculates aggregate totals"
-               }
-            },
-            "version":1
-         }
-      },
-      "settings":{
-         "remappings":[
-            "@openzeppelin-contracts-5.4.0-rc.1/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/",
-            "@openzeppelin-contracts-upgradeable-5.4.0-rc.1/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/",
-            "@openzeppelin/contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/",
-            "@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/",
-            "AMProxy/=dependencies/core-v2-staging/src/proxy/",
-            "config/=dependencies/spectra-contracts-configs-main/script/",
-            "core-v2-staging/=dependencies/core-v2-staging/",
-            "core-v2/=dependencies/core-v2-staging/",
-            "ds-test/=dependencies/core-v2-staging/lib/forge-std/lib/ds-test/src/",
-            "erc4626-tests/=dependencies/core-v2-staging/lib/openzeppelin-contracts/lib/erc4626-tests/",
-            "forge-std-1.9.7/=dependencies/forge-std-1.9.7/src/",
-            "forge-std/=dependencies/forge-std-1.9.7/src/",
-            "openzeppelin-contracts-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/",
-            "openzeppelin-contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/",
-            "openzeppelin-erc20-basic/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/",
-            "openzeppelin-erc20-extensions/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/token/ERC20/extensions/",
-            "openzeppelin-erc20/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/token/ERC20/",
-            "openzeppelin-math/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/",
-            "openzeppelin-proxy/=dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/proxy/utils/",
-            "openzeppelin-utils/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/",
-            "spectra-contracts-configs-main/=dependencies/spectra-contracts-configs-main/",
-            "spectra-contracts-configs/=dependencies/core-v2-staging/lib/",
-            "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/:@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.4.0-rc.1/",
-            "dependencies/core-v2-staging:script/=dependencies/core-v2-staging/script/",
-            "dependencies/core-v2-staging:src/=dependencies/core-v2-staging/src/"
-         ],
-         "optimizer":{
-            "enabled":false,
-            "runs":200
-         },
-         "metadata":{
-            "bytecodeHash":"ipfs"
-         },
-         "compilationTarget":{
-            "src/LimitOrderEngine.sol":"LimitOrderEngine"
-         },
-         "evmVersion":"cancun",
-         "libraries":{
-            
-         }
-      },
-      "sources":{
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/AccessManaged.sol":{
-            "keccak256":"0x99c633472387324f902c3c125938a98711d4cb0b077ae3999bb318d7d0435c19",
-            "urls":[
-               "bzz-raw://f39b65e6bc37152819275df8fe01252edf55f118d30d51e4ab9a585d94c1a881",
-               "dweb:/ipfs/QmYc7q1Anwgig2JbhLiKyDwU21w4QbY2Sogm7aoad7CLiC"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/AuthorityUtils.sol":{
-            "keccak256":"0x05fd06ae5bca9dc7470fb2dfae764315c81a84f591e86be6fec0c115474edc6c",
-            "urls":[
-               "bzz-raw://998ffed150fad3264d73c847f2ca35ee750d747ece382bb48885e8c8dce62941",
-               "dweb:/ipfs/QmSjacwVExF2T9ZFysQQ3vVLJbDQ16G7zd81SDxPCfNFxe"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAccessManaged.sol":{
-            "keccak256":"0x4ad12e231e8b1567e4086b134f5ff59a08cb8b1ea6d8fa9ecceec30b4b28ad89",
-            "urls":[
-               "bzz-raw://81657c0f105f4c92c1a67bcbc7a6afb6c2a937616b8168a63f3fdff61ea4957f",
-               "dweb:/ipfs/QmS3ZBTCr34uuVCXVRfuuvh5QRT9upruNhi222EjJ7tgJp"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAccessManager.sol":{
-            "keccak256":"0x3a129298f50d5e1e8d46d91eb6aa40e18183b76f6983e13a0a1e5f43a8faedb6",
-            "urls":[
-               "bzz-raw://e1a20642c110215a14f97d7cbd7048a19db9b9500b020b17b96138406ab6ab07",
-               "dweb:/ipfs/QmRbrcJjQzGnz7T6KYCpZYtDYpx6id2KSDis7DPQhye1Zr"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/access/manager/IAuthority.sol":{
-            "keccak256":"0xd7b800fcca190ec8030b5d5792d7b5e6de3213ab322ada322e905540c58edd3b",
-            "urls":[
-               "bzz-raw://b0d5da4f1aa7120b6fac945df72ff3661b0d1ee9bc175023ec29cecc6324c76b",
-               "dweb:/ipfs/QmPDSsk9WcVwx4Je1t59txPUzh7si4Hnhu11VPjrTwQFPL"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1271.sol":{
-            "keccak256":"0x67ddf13274cfd1dd994552801d8e2f67a32e2301d6680d7bb2eda99a7feff5eb",
-            "urls":[
-               "bzz-raw://137e025f914ff2d56889b68629337b5f4dc4cba181cd0a3ec42a2e0cdf1d396a",
-               "dweb:/ipfs/QmaVBNddWRuukyYZKAKDsvDZ64JWGCiMmF95cktsfH9muM"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1363.sol":{
-            "keccak256":"0xcef3dfbf36b24b3d0bd209f8e1869f4c86287878240f66e651b122d26448fcc3",
-            "urls":[
-               "bzz-raw://ebc799e73eaf8a32c7be984f422f5b237e4b36277251968c60f74b282ecd1c91",
-               "dweb:/ipfs/QmczzYkjSv93ZtPswneWbYSjkd4LEbhkg8iB4ZATvCEfCz"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC165.sol":{
-            "keccak256":"0x71f27f20e8998b0d0266a5b5a9a73346baf513c98f7fe941d13f293c6f5f30fa",
-            "urls":[
-               "bzz-raw://8a810b05b2727a18024c91842beb4a65c6785d477c931a0e679fedba4963f73c",
-               "dweb:/ipfs/QmdWk9H4YuKU9M86VsZD1syn4SMbVJCvoRGRwn74gLPRLG"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC1967.sol":{
-            "keccak256":"0x23353583409a0aa27f089fa1418033ea755d19843eb8337b58aeda2e9764a127",
-            "urls":[
-               "bzz-raw://705a41ec0e37e0e8625ac41671c292ff34c7039f133a4bb2121a658a1b88eb08",
-               "dweb:/ipfs/QmaQJwHqRFNnmnexuV8yJjKjzfHGi34MWm4MEhPu2teiJY"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC20.sol":{
-            "keccak256":"0x742c788bf2723742350a299027925399eb5b1da6b4971af846aabe742f7ce9fa",
-            "urls":[
-               "bzz-raw://3a001c31d79f8df22a8b8111c728ab6719c516391e7687a16648c84242c3641b",
-               "dweb:/ipfs/QmT7uM2J8pPKUjJJzVNYQiswd4eG6AU1CWDecCWdHrm3oz"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC20Metadata.sol":{
-            "keccak256":"0x877f2cab8e4dfa6174d0177f04181319da118a7e367493ad7c68ee4cb8be7205",
-            "urls":[
-               "bzz-raw://c368c7a1eec4c3a6ae815e775f9bdbdd0130ad0c0b09447e9b9d56a2a4cafe2f",
-               "dweb:/ipfs/QmbbMtEf5ZY6ZpQKLsVvmsHLB7A639qnEiAqhjSP3k17tY"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC3156FlashBorrower.sol":{
-            "keccak256":"0xd470da87c982da3f6be8555b63f10d66462054def9d7da20aae37c3ee3c96d58",
-            "urls":[
-               "bzz-raw://c76692163f771760363ff3001755a6e1331c0b25b23ddaf5e072c0ed67f4b5cc",
-               "dweb:/ipfs/QmXhYb6dwmoGq1ZcGfbuC5RaYFaDLG3FdqhHC4GqNe75DP"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC3156FlashLender.sol":{
-            "keccak256":"0xbf67f5abbdb40a69d887f34bb9c578945c4d80ea5566264a16165bf49d06665b",
-            "urls":[
-               "bzz-raw://6e325477bf279e74e4c4d13d5014a60697f35d20134ce424970f2336a7740423",
-               "dweb:/ipfs/QmVrthF7KY6kp2RXrfiCZk9uZwPYHdPCqgiPpDeShJWu3z"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC4626.sol":{
-            "keccak256":"0x085fcdfdf42d0092040e702303f54f9a0a3540bf25921588f0c44f2a870485df",
-            "urls":[
-               "bzz-raw://cb8e63b28c91aaa8c5c6e393c39d53ced9868128ce60f8a0d38d57f7eebfa59f",
-               "dweb:/ipfs/QmNfU4XSGnv8eD5UREt7Rs5TiLT2iVGd2CWpka3brngmRT"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC5267.sol":{
-            "keccak256":"0x473d635a93adf200d4ec9ef1cb3ba9d33230d546fa0eb8ab95e6ed5a461da5d9",
-            "urls":[
-               "bzz-raw://28dd2f7722f144efa18ad2797c744d214e02495f948d4d73b354ef049a6f813f",
-               "dweb:/ipfs/QmeSyAoJk1FuS6F7MzJj6dvnqd6jNz6pNP2WjjLPhDLHdg"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/interfaces/IERC7913.sol":{
-            "keccak256":"0xfa287c745741ef58af71e1068ebf9771fe55bc17c9efe39517d942a005744f24",
-            "urls":[
-               "bzz-raw://78a7f7ab52e2ea38fb0f79ad786bb575af5e6a60a44a31bef37fbdeffd88330f",
-               "dweb:/ipfs/QmZSiVgsapHHmQspCYDVGjayZANcvct4m2i65QdC2N3VGU"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/proxy/ERC1967/ERC1967Proxy.sol":{
-            "keccak256":"0xa3066ff86b94128a9d3956a63a0511fa1aae41bd455772ab587b32ff322acb2e",
-            "urls":[
-               "bzz-raw://bf7b192fd82acf6187970c80548f624b1b9c80425b62fa49e7fdb538a52de049",
-               "dweb:/ipfs/QmWXG1YCde1tqDYTbNwjkZDWVgPEjzaQGSDqWkyKLzaNua"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/proxy/ERC1967/ERC1967Utils.sol":{
-            "keccak256":"0x0f42d3c4b0cc63a53bea0cbdc22cad383a741ba0e15e7009daf337c056ed4efb",
-            "urls":[
-               "bzz-raw://1c481c794adcbf16967b04998a95db13d50f1409f1b99d938334833645b62fe8",
-               "dweb:/ipfs/QmapU5kJur7GQ6CQseP2bEAYqPKFGHJAhcsSz4QgNrVase"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/proxy/Proxy.sol":{
-            "keccak256":"0xc3f2ec76a3de8ed7a7007c46166f5550c72c7709e3fc7e8bb3111a7191cdedbd",
-            "urls":[
-               "bzz-raw://e73efb4c2ca655882dc237c6b4f234a9bd36d97159d8fcaa837eb01171f726ac",
-               "dweb:/ipfs/QmTNnnv7Gu5fs5G1ZMh7Fexp8N4XUs3XrNAngjcxgiss3e"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/proxy/beacon/IBeacon.sol":{
-            "keccak256":"0x8e23a5e06f7fc9df2ae25396f8f0f8c8901f9a66a10a1e03f3138a04a69db7bc",
-            "urls":[
-               "bzz-raw://fa2c8656590fac2915bb5ff3416efd4d51774d34ea5ec1ca20566df7ead51295",
-               "dweb:/ipfs/QmXxPTA1U7YUHhVfJPRe6UxcADu4T1C9673u1u3hiQjKJS"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/IERC20.sol":{
-            "keccak256":"0xaa5c002dccc71cf9d6dd92a9fa87f205f32b0b9204303c442d567bfcb832d69d",
-            "urls":[
-               "bzz-raw://f17355804cadb61737c6d7ebf9539cd27eacd8a9099ffe711ce9dc0a2dd07442",
-               "dweb:/ipfs/QmSVBcaVaaC9SxVsYsmfY1U3du3inqbNGPEpcMY4KkRrrj"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/extensions/IERC20Metadata.sol":{
-            "keccak256":"0x090e3e7ffd747b5546cb7033e5425ec7fc8813da81f8bee455318fd8af5cc3a0",
-            "urls":[
-               "bzz-raw://423facd62c0103f6810c7b43c1cf3002e8728a9e3aa57c32c46d100137a6f2ae",
-               "dweb:/ipfs/QmPcMF3srsURFQRpQNCC5ALv8eGVFeupK8TYirBNTWVC8b"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/extensions/IERC20Permit.sol":{
-            "keccak256":"0xa20fb0cd8147050fa1bcd21d76baf4b696879be5cc52f91bd3261dfd1b4acd2f",
-            "urls":[
-               "bzz-raw://0df62ff0cc45ad15d2b2d3a99842c45a2f9ad6fc99ce56112e36bd2da417d229",
-               "dweb:/ipfs/QmYxvt5E1PhvTJXskBWU6Y1N56dT6gzzTUDSKXmmKSWHkQ"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/token/ERC20/utils/SafeERC20.sol":{
-            "keccak256":"0x982c5cb790ab941d1e04f807120a71709d4c313ba0bfc16006447ffbd27fbbd5",
-            "urls":[
-               "bzz-raw://8150ceb4ac947e8a442b2a9c017e01e880b2be2dd958f1fa9bc405f4c5a86508",
-               "dweb:/ipfs/QmbcBmFX66AY6Kbhnd5gx7zpkgqnUafo43XnmayAM7zVdB"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Address.sol":{
-            "keccak256":"0xf17347b68bf7a199ebb71c8ee074edf31c9302f26013050d7f28f88360fab83a",
-            "urls":[
-               "bzz-raw://44fb441daade9ca80695f2bec4f118eee3a307ded5de4597e552d9e6a7b43bba",
-               "dweb:/ipfs/Qmc6VR5eTSiv3P2cF4tENXDH9JNcErFFzQzY21wZPrgzfH"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Bytes.sol":{
-            "keccak256":"0xee79e30c45319d56e7536317e1776686ec2d475795a27c3f2ac7e9c2f4edef7f",
-            "urls":[
-               "bzz-raw://d0952f3c09421d8b2b3896b4789ad655a114b9206365b5363c1dd0a75583997d",
-               "dweb:/ipfs/QmQPemDMHjWhhLmazue7gHnZRYxcbz9nbz4pKcC7ioSFyz"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Context.sol":{
-            "keccak256":"0x493033a8d1b176a037b2cc6a04dad01a5c157722049bbecf632ca876224dd4b2",
-            "urls":[
-               "bzz-raw://6a708e8a5bdb1011c2c381c9a5cfd8a9a956d7d0a9dc1bd8bcdaf52f76ef2f12",
-               "dweb:/ipfs/Qmax9WHBnVsZP46ZxEMNRQpLQnrdE4dK8LehML1Py8FowF"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Errors.sol":{
-            "keccak256":"0x6afa713bfd42cf0f7656efa91201007ac465e42049d7de1d50753a373648c123",
-            "urls":[
-               "bzz-raw://ba1d02f4847670a1b83dec9f7d37f0b0418d6043447b69f3a29a5f9efc547fcf",
-               "dweb:/ipfs/QmQ7iH2keLNUKgq2xSWcRmuBE5eZ3F5whYAkAGzCNNoEWB"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Panic.sol":{
-            "keccak256":"0xf7fe324703a64fc51702311dc51562d5cb1497734f074e4f483bfb6717572d7a",
-            "urls":[
-               "bzz-raw://c6a5ff4f9fd8649b7ee20800b7fa387d3465bd77cf20c2d1068cd5c98e1ed57a",
-               "dweb:/ipfs/QmVSaVJf9FXFhdYEYeCEfjMVHrxDh5qL4CGkxdMWpQCrqG"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/StorageSlot.sol":{
-            "keccak256":"0xcf74f855663ce2ae00ed8352666b7935f6cddea2932fdf2c3ecd30a9b1cd0e97",
-            "urls":[
-               "bzz-raw://9f660b1f351b757dfe01438e59888f31f33ded3afcf5cb5b0d9bf9aa6f320a8b",
-               "dweb:/ipfs/QmarDJ5hZEgBtCmmrVzEZWjub9769eD686jmzb2XpSU1cM"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/Strings.sol":{
-            "keccak256":"0x72d89c30d5c7c7f7923677b3738ceffe5a5671f885b4637badd0084c3f438213",
-            "urls":[
-               "bzz-raw://15ad622659ea59783478bc73db26d57a74f400aef716a6478613919e45bd4b71",
-               "dweb:/ipfs/QmPcaMREGhoehgMhY9s6BUrsVoK7F6YNU1xkG4VFe5yXjT"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/ECDSA.sol":{
-            "keccak256":"0x69f54c02b7d81d505910ec198c11ed4c6a728418a868b906b4a0cf29946fda84",
-            "urls":[
-               "bzz-raw://8e25e4bdb7ae1f21d23bfee996e22736fc0ab44cfabedac82a757b1edc5623b9",
-               "dweb:/ipfs/QmQdWQvB6JCP9ZMbzi8EvQ1PTETqkcTWrbcVurS7DKpa5n"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/MessageHashUtils.sol":{
-            "keccak256":"0x26670fef37d4adf55570ba78815eec5f31cb017e708f61886add4fc4da665631",
-            "urls":[
-               "bzz-raw://b16d45febff462bafd8a5669f904796a835baf607df58a8461916d3bf4f08c59",
-               "dweb:/ipfs/QmU2eJFpjmT4vxeJWJyLeQb8Xht1kdB8Y6MKLDPFA9WPux"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/cryptography/SignatureChecker.sol":{
-            "keccak256":"0x60da29c52e83ab33d9335cd153b7ef333d1758731eb5a600d13228a5ea30a704",
-            "urls":[
-               "bzz-raw://f9d21b7b68fc9b5406d8e762aaef2d4f3d06de774b37486555404919394a6b35",
-               "dweb:/ipfs/QmQZYwwhyZyYfmcKKeLm6g7CBb8tF42XUVXE9mvywLnUJQ"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/introspection/IERC165.sol":{
-            "keccak256":"0x2820b23a27421cbb9be0239e2210efbcdb73c3224e1a48acb7daff8d7d26964f",
-            "urls":[
-               "bzz-raw://a00d4c01544a03232adb233c3e82d1b1eb82bde78df17f05fd56232f2773bd23",
-               "dweb:/ipfs/QmZ9tPFfYYMdc3PCJPcAWCdvJ3Gt646MJxk2RZ3D9tjeZN"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/Math.sol":{
-            "keccak256":"0x1225214420c83ebcca88f2ae2b50f053aaa7df7bd684c3e878d334627f2edfc6",
-            "urls":[
-               "bzz-raw://6c5fab4970634f9ab9a620983dc1c8a30153981a0b1a521666e269d0a11399d3",
-               "dweb:/ipfs/QmVRnBC575MESGkEHndjujtR7qub2FzU9RWy9eKLp4hPZB"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/SafeCast.sol":{
-            "keccak256":"0x195533c86d0ef72bcc06456a4f66a9b941f38eb403739b00f21fd7c1abd1ae54",
-            "urls":[
-               "bzz-raw://b1d578337048cad08c1c03041cca5978eff5428aa130c781b271ad9e5566e1f8",
-               "dweb:/ipfs/QmPFKL2r9CBsMwmUqqdcFPfHZB2qcs9g1HDrPxzWSxomvy"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-5.4.0-rc.1/utils/math/SignedMath.sol":{
-            "keccak256":"0xb1970fac7b64e6c09611e6691791e848d5e3fe410fa5899e7df2e0afd77a99e3",
-            "urls":[
-               "bzz-raw://db5fbb3dddd8b7047465b62575d96231ba8a2774d37fb4737fbf23340fabbb03",
-               "dweb:/ipfs/QmVUSvooZKEdEdap619tcJjTLcAuH6QBdZqAzWwnAXZAWJ"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/access/manager/AccessManagedUpgradeable.sol":{
-            "keccak256":"0xafc6430a5a632a57bf0e1596dccdad8f208f449cfc340878dc1789e5f5b570d5",
-            "urls":[
-               "bzz-raw://1935bb38eac62a468fdc3f00174e4cb28b476668895ddfea5e0bcf56297b8145",
-               "dweb:/ipfs/QmVmSMB2tykT9t5ZoMkREn2zNzYtK2ufNdxRYo3B7MLvVT"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/proxy/utils/Initializable.sol":{
-            "keccak256":"0xdb4d24ee2c087c391d587cd17adfe5b3f9d93b3110b1388c2ab6c7c0ad1dcd05",
-            "urls":[
-               "bzz-raw://ab7b6d5b9e2b88176312967fe0f0e78f3d9a1422fa5e4b64e2440c35869b5d08",
-               "dweb:/ipfs/QmXKYWWyzcLg1B2k7Sb1qkEXgLCYfXecR9wYW5obRzWP1Q"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/ContextUpgradeable.sol":{
-            "keccak256":"0xdbef5f0c787055227243a7318ef74c8a5a1108ca3a07f2b3a00ef67769e1e397",
-            "urls":[
-               "bzz-raw://08e39f23d5b4692f9a40803e53a8156b72b4c1f9902a88cd65ba964db103dab9",
-               "dweb:/ipfs/QmPKn6EYDgpga7KtpkA8wV2yJCYGMtc9K4LkJfhKX2RVSV"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/PausableUpgradeable.sol":{
-            "keccak256":"0xa6bf6b7efe0e6625a9dcd30c5ddf52c4c24fe8372f37c7de9dbf5034746768d5",
-            "urls":[
-               "bzz-raw://8c353ee3705bbf6fadb84c0fb10ef1b736e8ca3ca1867814349d1487ed207beb",
-               "dweb:/ipfs/QmcugaPssrzGGE8q4YZKm2ZhnD3kCijjcgdWWg76nWt3FY"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/@openzeppelin-contracts-upgradeable-5.4.0-rc.1/utils/cryptography/EIP712Upgradeable.sol":{
-            "keccak256":"0xba34a957324b4b1cb867111b948afc0cda72f5e9fdc7cb9b9b7bfeb0c2ad4edb",
-            "urls":[
-               "bzz-raw://214590a0ca86c1209ef46f240c06ea1b9eb64e55bc98c2e3efc470fb682002f0",
-               "dweb:/ipfs/Qme7wm5XTn8U3Xmn35DtpXw817888Drjm9YhJP2vQAunqV"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/core-v2-staging/src/interfaces/IPrincipalToken.sol":{
-            "keccak256":"0x8fb04690eb8cca9c4e9c68ac7991837ff4a383c2c27869259c3b3553aeaa32b8",
-            "urls":[
-               "bzz-raw://5f6c1d66a951054e59b93e84f9de6af9abd584a46aad1bb558bdc338c6715abc",
-               "dweb:/ipfs/QmZyAggpy2U82hgZsq3Ri3GMNDDi2tGD62s1USGxqoZTa1"
-            ],
-            "license":"BUSL-1.1"
-         },
-         "dependencies/core-v2-staging/src/interfaces/IRegistry.sol":{
-            "keccak256":"0x404a0ff1e75d1db0f3432718c66b49e6ca4df8f1df4573fb93c1c143475793df",
-            "urls":[
-               "bzz-raw://6812a64f888dcd38573f3c8daca5b88404c2bc7a107b79af281ede6f5119063d",
-               "dweb:/ipfs/QmPDKUG6bspqPzSWvK2AM1RLemBpSGhY3ZtR7aASsgXAJb"
-            ],
-            "license":"BUSL-1.1"
-         },
-         "dependencies/core-v2-staging/src/libraries/LogExpMath.sol":{
-            "keccak256":"0x83fa012405dacb88992aa6653d8cf1fe6a00def6abd09e715c79f7a5a5a8fe74",
-            "urls":[
-               "bzz-raw://355bc2a9afcc3a44a90223ab6f42cbdf71722d7ab145ce429c5406052530fba5",
-               "dweb:/ipfs/QmUSPm8tkEJ275eLQ7MP9AWcxs1BMtyreeZyFGK1eD9GEL"
-            ],
-            "license":"GPL-3.0-or-later"
-         },
-         "dependencies/core-v2-staging/src/libraries/RayMath.sol":{
-            "keccak256":"0xeb628b5cf03604856852b140401593daefc51cde6b426f2bccb7b21a4a6f3bff",
-            "urls":[
-               "bzz-raw://0d0eb1f485646176a868b379fd445c06ce97d9ed78809660428484dbca8f943e",
-               "dweb:/ipfs/QmWHgYkWbwRACsfhriTwRv3sp1BZ28UobXSHWfQ62WouY7"
-            ],
-            "license":"BUSL-1.1"
-         },
-         "dependencies/core-v2-staging/src/proxy/AMProxyAdmin.sol":{
-            "keccak256":"0xb83d5d3a362a363288da8180275ac79043cacf4bf1f33065794fdd7c518265aa",
-            "urls":[
-               "bzz-raw://8ff95e79befdd80d253e5fae71663c4b8e93f03b84735ead60dfcd1da671471f",
-               "dweb:/ipfs/QmabMVizi6iVKqscnpCybaAW7tshFunPfPsZ42cEADgsa8"
-            ],
-            "license":"MIT"
-         },
-         "dependencies/core-v2-staging/src/proxy/AMTransparentUpgradeableProxy.sol":{
-            "keccak256":"0xc90c7d52baac84ec544e8e6a6027118e3135b7630fef6eeac344c34812777ee3",
-            "urls":[
-               "bzz-raw://e7000d4e3057705801232342ae90b235af2a217b3c8d369b682ee01950cae2d8",
-               "dweb:/ipfs/QmXxX1HXHhC1YFE7YkLEvjDzr8rFPLyyeKqiuPFTpdsw9v"
-            ],
-            "license":"MIT"
-         },
-         "src/LimitOrderEngine.sol":{
-            "keccak256":"0x2258531cefbe6483092dec46a53a7db7174c8ff86c257ca10565589e19b00c95",
-            "urls":[
-               "bzz-raw://244e848af2250318b669238a4ab5aba1e5c2fc873d87f34a82f382b9fbffa400",
-               "dweb:/ipfs/QmdKCBrnkSka3w8DZwrxVNf35oCUL9nXWZ3BmzhMvaaFWm"
-            ],
-            "license":"BUSL-1.1"
-         },
-         "src/NonceManager.sol":{
-            "keccak256":"0x7b02825144810dea809676e788b2bd41f825be4e1aa9cc63618d5b84147b66bd",
-            "urls":[
-               "bzz-raw://48132b3808d45cad91be335f2c876b1d07160cce8b3ac60d575d63e3d7849f7e",
-               "dweb:/ipfs/QmQKNXVYWh5Wi2rBhrWo7Q6PtikCf5no1ap2CwXzweUVDj"
-            ],
-            "license":"MIT"
-         },
-         "src/interfaces/ILimitOrderEngine.sol":{
-            "keccak256":"0x453f83a46c8814560b2c77f9a8bfc4e263f90832ccb00a4f197323037974fb25",
-            "urls":[
-               "bzz-raw://37b40432ce524a0ab905c24361c9b586d526b34471e2197151966ac25e036c4b",
-               "dweb:/ipfs/QmXxq2yGz6kfXgPzs9YueXW7Ens2PpMREkXyQ8SdgpyWrs"
-            ],
-            "license":"BUSL-1.1"
-         },
-         "src/interfaces/IRegistryGetter.sol":{
-            "keccak256":"0x9414228123d5d22c89b08f274d74065dbe1f1cd3f2e2df042c041bb0921515eb",
-            "urls":[
-               "bzz-raw://c5f194979aed56474e7586e632fc9c8460074f291a300199673bf5f78e36c16f",
-               "dweb:/ipfs/QmVrzqmXHuP8B4SduhWApYeHXdnMNVwHYUw4pTF4HbGhZd"
-            ],
-            "license":"BUSL-1.1"
-         }
-      },
-      "version":1
-   },
-   "id":131
+    },
+    "version": 1
+  },
+  "id": 116
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -481,8 +481,19 @@ type OnChainOrderStatus @entity(immutable: false) {
     orderHash: Bytes!               # The raw order hash
     totalFilled: BigInt!            # Accumulated actualMaking from OrderFilled
     cancelled: Boolean!             # True if OrderCanceled was emitted
-    updatedAt: BigInt! @index       # Timestamp of the last update (OrderFilled or OrderCanceled) - (TODO: check indexed for time-based queries)
-    updatedAtBlock: BigInt! @index  # Block number of the last update (OrderFilled or OrderCanceled) -(TODO: check indexed for block-based queries)
+    isPreSigned: Boolean!           # True if OrderPreSigned was emitted (on-chain registration)
+    updatedAt: BigInt! @index       # Timestamp of the last update (OrderFilled, OrderCanceled or OrderPreSigned) - (TODO: check indexed for time-based queries)
+    updatedAtBlock: BigInt! @index  # Block number of the last update (OrderFilled, OrderCanceled or OrderPreSigned) -(TODO: check indexed for block-based queries)
+}
+
+# Tracks the protocol limit-order fee held on the LimitOrderEngine.
+# Singleton entity (id = "limit-order-fee"), updated on each LimitOrderFeeChange event.
+type LimitOrderFee @entity(immutable: false) {
+    id: ID!                          # Constant: "limit-order-fee"
+    currentFee: BigInt!             # Current fee in 18-decimal WAD (newLimitOrderFee from the last event)
+    previousFee: BigInt!            # The fee value prior to the last change
+    updatedAt: BigInt!              # Timestamp of the last LimitOrderFeeChange event
+    updatedAtBlock: BigInt!         # Block number of the last LimitOrderFeeChange event
 }
 
 ####################

--- a/src/mappings/limitOrders.ts
+++ b/src/mappings/limitOrders.ts
@@ -3,6 +3,8 @@ import { BigInt, Address, Bytes, ethereum } from "@graphprotocol/graph-ts"
 import {
     OrderFilled as OrderFilledEvent,
     OrderCanceled as OrderCanceledEvent,
+    OrderPreSigned as OrderPreSignedEvent,
+    LimitOrderFeeChange as LimitOrderFeeChangeEvent,
     NonceIncreased as NonceIncreasedEvent,
     AuthorityUpdated as AuthorityUpdatedEvent,
     FeeRecipientUpdated as FeeRecipientUpdatedEvent,
@@ -14,7 +16,11 @@ import {
 // since NonceManager is included as an ABI in the LimitOrderEngine data source
 // (LimitOrderEngine extends NonceManage hence they have the same address))
 // Import entities
-import { UserNonce, OnChainOrderStatus } from "../../generated/schema"
+import {
+    UserNonce,
+    OnChainOrderStatus,
+    LimitOrderFee,
+} from "../../generated/schema"
 import { ZERO_BI, ZERO_BD } from "../constants"
 // Import utilities
 import { logInfo, logWarning } from "../utils/log"
@@ -38,6 +44,7 @@ export function handleOrderFilled(event: OrderFilledEvent): void {
         orderStatus.orderHash = event.params.orderHash
         orderStatus.totalFilled = ZERO_BI
         orderStatus.cancelled = false
+        orderStatus.isPreSigned = false
     }
 
     // Update order status with new fill
@@ -69,6 +76,7 @@ export function handleOrderCanceled(event: OrderCanceledEvent): void {
         orderStatus = new OnChainOrderStatus(orderHashId)
         orderStatus.orderHash = event.params.orderHash
         orderStatus.totalFilled = ZERO_BI
+        orderStatus.isPreSigned = false
     }
 
     // Mark the order as cancelled
@@ -78,6 +86,55 @@ export function handleOrderCanceled(event: OrderCanceledEvent): void {
 
     // Single save operation
     orderStatus.save()
+}
+
+/**
+ * Handle OrderPreSigned event from LimitOrderEngine
+ * Emitted when a maker registers an order on-chain via preSignSingle/preSignBatch,
+ * allowing fillers to skip EIP-712 signature verification.
+ * Fires before any fill, so totalFilled is ZERO_BI when the entity is first created here.
+ */
+export function handleOrderPreSigned(event: OrderPreSignedEvent): void {
+    // Use orderHash hex string as entity ID for efficient lookups
+    const orderHashId = event.params.orderHash.toHexString()
+
+    // Get or create OnChainOrderStatus entity
+    let orderStatus = OnChainOrderStatus.load(orderHashId)
+    if (orderStatus == null) {
+        orderStatus = new OnChainOrderStatus(orderHashId)
+        orderStatus.orderHash = event.params.orderHash
+        orderStatus.totalFilled = ZERO_BI
+        orderStatus.cancelled = false
+    }
+
+    // Mark the order as pre-signed (registered on-chain)
+    orderStatus.isPreSigned = true
+    orderStatus.updatedAt = event.block.timestamp
+    orderStatus.updatedAtBlock = event.block.number
+
+    orderStatus.save()
+}
+
+/**
+ * Handle LimitOrderFeeChange event from LimitOrderEngine
+ * Emitted when the protocol limit-order fee is updated via setLimitOrderFee.
+ * Tracked as a singleton entity holding the current and previous fee (18-decimal WAD).
+ */
+export function handleLimitOrderFeeChange(
+    event: LimitOrderFeeChangeEvent
+): void {
+    // Singleton entity for the protocol-wide limit-order fee
+    let fee = LimitOrderFee.load("limit-order-fee")
+    if (fee == null) {
+        fee = new LimitOrderFee("limit-order-fee")
+    }
+
+    fee.previousFee = event.params.previousLimitOrderFee
+    fee.currentFee = event.params.newLimitOrderFee
+    fee.updatedAt = event.block.timestamp
+    fee.updatedAtBlock = event.block.number
+
+    fee.save()
 }
 
 /**

--- a/src/tests/events/LimitOrders.ts
+++ b/src/tests/events/LimitOrders.ts
@@ -1,0 +1,130 @@
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts"
+import { newMockEvent } from "matchstick-as/assembly"
+
+import {
+    OrderFilled,
+    OrderCanceled,
+    OrderPreSigned,
+    LimitOrderFeeChange,
+    NonceIncreased,
+} from "../../../generated/LimitOrderEngine/LimitOrderEngine"
+
+// Deterministic block context so handlers write predictable updatedAt / updatedAtBlock
+export const LIMIT_ORDER_ENGINE_ADDRESS_MOCK = Address.fromString(
+    "0x1234567890123456789012345678901234567890"
+)
+export const DEFAULT_TIMESTAMP = BigInt.fromI32(1700000000)
+export const DEFAULT_BLOCK = BigInt.fromI32(12345)
+
+function withBlock<T extends ethereum.Event>(event: T): T {
+    event.address = LIMIT_ORDER_ENGINE_ADDRESS_MOCK
+    event.block.timestamp = DEFAULT_TIMESTAMP
+    event.block.number = DEFAULT_BLOCK
+    return event
+}
+
+// OrderFilled(bytes32 orderHash, uint256 actualMaking) — both non-indexed
+export function createOrderFilledEvent(
+    orderHash: Bytes,
+    actualMaking: BigInt
+): OrderFilled {
+    let event = withBlock(changetype<OrderFilled>(newMockEvent()))
+
+    let orderHashParam = new ethereum.EventParam(
+        "orderHash",
+        ethereum.Value.fromFixedBytes(orderHash)
+    )
+    let actualMakingParam = new ethereum.EventParam(
+        "actualMaking",
+        ethereum.Value.fromUnsignedBigInt(actualMaking)
+    )
+
+    event.parameters = [orderHashParam, actualMakingParam]
+    return event
+}
+
+// OrderCanceled(address maker, bytes32 orderHash) — both non-indexed
+export function createOrderCanceledEvent(
+    maker: Address,
+    orderHash: Bytes
+): OrderCanceled {
+    let event = withBlock(changetype<OrderCanceled>(newMockEvent()))
+
+    let makerParam = new ethereum.EventParam(
+        "maker",
+        ethereum.Value.fromAddress(maker)
+    )
+    let orderHashParam = new ethereum.EventParam(
+        "orderHash",
+        ethereum.Value.fromFixedBytes(orderHash)
+    )
+
+    event.parameters = [makerParam, orderHashParam]
+    return event
+}
+
+// OrderPreSigned(bytes32 indexed orderHash, address indexed maker)
+// indexed params are still placed in declaration order in the params array
+export function createOrderPreSignedEvent(
+    orderHash: Bytes,
+    maker: Address
+): OrderPreSigned {
+    let event = withBlock(changetype<OrderPreSigned>(newMockEvent()))
+
+    let orderHashParam = new ethereum.EventParam(
+        "orderHash",
+        ethereum.Value.fromFixedBytes(orderHash)
+    )
+    let makerParam = new ethereum.EventParam(
+        "maker",
+        ethereum.Value.fromAddress(maker)
+    )
+
+    event.parameters = [orderHashParam, makerParam]
+    return event
+}
+
+// LimitOrderFeeChange(uint256 previousLimitOrderFee, uint256 newLimitOrderFee)
+export function createLimitOrderFeeChangeEvent(
+    previousFee: BigInt,
+    newFee: BigInt
+): LimitOrderFeeChange {
+    let event = withBlock(changetype<LimitOrderFeeChange>(newMockEvent()))
+
+    let previousParam = new ethereum.EventParam(
+        "previousLimitOrderFee",
+        ethereum.Value.fromUnsignedBigInt(previousFee)
+    )
+    let newParam = new ethereum.EventParam(
+        "newLimitOrderFee",
+        ethereum.Value.fromUnsignedBigInt(newFee)
+    )
+
+    event.parameters = [previousParam, newParam]
+    return event
+}
+
+// NonceIncreased(address indexed maker, uint256 oldNonce, uint256 newNonce)
+export function createNonceIncreasedEvent(
+    maker: Address,
+    oldNonce: BigInt,
+    newNonce: BigInt
+): NonceIncreased {
+    let event = withBlock(changetype<NonceIncreased>(newMockEvent()))
+
+    let makerParam = new ethereum.EventParam(
+        "maker",
+        ethereum.Value.fromAddress(maker)
+    )
+    let oldNonceParam = new ethereum.EventParam(
+        "oldNonce",
+        ethereum.Value.fromUnsignedBigInt(oldNonce)
+    )
+    let newNonceParam = new ethereum.EventParam(
+        "newNonce",
+        ethereum.Value.fromUnsignedBigInt(newNonce)
+    )
+
+    event.parameters = [makerParam, oldNonceParam, newNonceParam]
+    return event
+}

--- a/src/tests/limitOrders.test.ts
+++ b/src/tests/limitOrders.test.ts
@@ -2,753 +2,259 @@ import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts"
 import {
     describe,
     test,
-    beforeAll,
-    afterAll,
+    beforeEach,
     clearStore,
     assert,
-    log,
 } from "matchstick-as/assembly/index"
 
-import { UserNonce, OnChainOrderStatus } from "../../generated/schema"
+import {
+    handleOrderFilled,
+    handleOrderCanceled,
+    handleOrderPreSigned,
+    handleLimitOrderFeeChange,
+    handleNonceIncreased,
+    handleNonceManagerNonceIncreased,
+} from "../mappings/limitOrders"
+import {
+    createOrderFilledEvent,
+    createOrderCanceledEvent,
+    createOrderPreSignedEvent,
+    createLimitOrderFeeChangeEvent,
+    createNonceIncreasedEvent,
+    DEFAULT_TIMESTAMP,
+    DEFAULT_BLOCK,
+} from "./events/LimitOrders"
 
-// Custom performance measurement utilities
-class PerformanceTimer {
-    private operationCount: i32 = 0
-    private testName: string = ""
+const ORDER_STATUS = "OnChainOrderStatus"
+const USER_NONCE = "UserNonce"
+const LIMIT_ORDER_FEE = "LimitOrderFee"
+const FEE_ID = "limit-order-fee"
 
-    constructor(testName: string) {
-        this.testName = testName
-    }
+const ORDER_HASH = Bytes.fromHexString(
+    "0x1111111111111111111111111111111111111111111111111111111111111111"
+)
+const ORDER_ID = ORDER_HASH.toHexString()
+const MAKER = Address.fromString("0x2222222222222222222222222222222222222222")
 
-    start(): void {
-        this.operationCount = 0
-        log.info("🚀 Starting performance test: {}", [this.testName])
-    }
-
-    incrementOperation(): void {
-        this.operationCount++
-    }
-
-    end(): i32 {
-        log.info('⏱️  Test "{}" completed {} operations', [
-            this.testName,
-            this.operationCount.toString(),
-        ])
-        return this.operationCount
-    }
-
-    static logOperation(operationName: string): void {
-        log.info("📊 Executing operation: {}", [operationName])
-    }
-}
-
-// Performance metrics collector
-class PerformanceMetrics {
-    static entityCreationCount: i32 = 0
-    static queryCount: i32 = 0
-    static saveCount: i32 = 0
-    static assertionCount: i32 = 0
-
-    static recordEntityCreation(): void {
-        this.entityCreationCount++
-        log.info("📈 Entity creation #{} completed", [
-            this.entityCreationCount.toString(),
-        ])
-    }
-
-    static recordQuery(): void {
-        this.queryCount++
-        log.info("🔍 Query #{} completed", [this.queryCount.toString()])
-    }
-
-    static recordSave(): void {
-        this.saveCount++
-        log.info("💾 Save operation #{} completed", [this.saveCount.toString()])
-    }
-
-    static recordAssertion(): void {
-        this.assertionCount++
-        log.info("✅ Assertion #{} completed", [this.assertionCount.toString()])
-    }
-
-    static printSummary(): void {
-        log.info("📊 PERFORMANCE SUMMARY 📊", [])
-        log.info("Total Entity Creations: {}", [
-            this.entityCreationCount.toString(),
-        ])
-        log.info("Total Queries: {}", [this.queryCount.toString()])
-        log.info("Total Saves: {}", [this.saveCount.toString()])
-        log.info("Total Assertions: {}", [this.assertionCount.toString()])
-        const totalOperations =
-            this.entityCreationCount +
-            this.queryCount +
-            this.saveCount +
-            this.assertionCount
-        log.info("🎯 Total Operations: {}", [totalOperations.toString()])
-    }
-
-    static reset(): void {
-        this.entityCreationCount = 0
-        this.queryCount = 0
-        this.saveCount = 0
-        this.assertionCount = 0
-    }
-}
-
-describe("Limit Orders", () => {
-    beforeAll(() => {
+describe("Limit Orders - handlers", () => {
+    beforeEach(() => {
         clearStore()
-        PerformanceMetrics.reset()
-        log.info("🧪 Starting Limit Orders Performance Test Suite", [])
     })
 
-    afterAll(() => {
-        PerformanceMetrics.printSummary()
-        clearStore()
-        log.info("🏁 Limit Orders Performance Test Suite Completed", [])
-    })
-
-    describe("UserNonce Entity", () => {
-        test("Should create UserNonce entity with correct fields", () => {
-            const timer = new PerformanceTimer("UserNonce Entity Creation")
-            timer.start()
-
-            let userAddress = Address.fromString(
-                "0x1234567890123456789012345678901234567890"
+    describe("handleOrderFilled", () => {
+        test("creates OnChainOrderStatus with defaults and records the fill", () => {
+            handleOrderFilled(
+                createOrderFilledEvent(ORDER_HASH, BigInt.fromI32(500))
             )
-            let entityId = "nonce-" + userAddress.toHexString()
-            let latestNonce = BigInt.fromI32(10)
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
-
-            // Track entity creation
-            PerformanceTimer.logOperation("UserNonce entity creation")
-            let entity = new UserNonce(entityId)
-            entity.user = userAddress
-            entity.latestNonce = latestNonce
-            entity.updatedAt = timestamp
-            entity.updatedAtBlock = blockNumber
-            PerformanceMetrics.recordEntityCreation()
-
-            // Track save operation
-            PerformanceTimer.logOperation("UserNonce save operation")
-            entity.save()
-            PerformanceMetrics.recordSave()
-
-            // Track field assertions
-            PerformanceTimer.logOperation("UserNonce field assertions")
-            assert.fieldEquals(
-                "UserNonce",
-                entityId,
-                "user",
-                userAddress.toHexString()
-            )
-            PerformanceMetrics.recordAssertion()
-            assert.fieldEquals(
-                "UserNonce",
-                entityId,
-                "latestNonce",
-                latestNonce.toString()
-            )
-            PerformanceMetrics.recordAssertion()
-            assert.fieldEquals(
-                "UserNonce",
-                entityId,
-                "updatedAt",
-                timestamp.toString()
-            )
-            PerformanceMetrics.recordAssertion()
-            assert.fieldEquals(
-                "UserNonce",
-                entityId,
-                "updatedAtBlock",
-                blockNumber.toString()
-            )
-            PerformanceMetrics.recordAssertion()
-            PerformanceMetrics.recordQuery()
-
-            const totalDuration = timer.end()
-            log.info("🎯 UserNonce test completed with total duration: {} ms", [
-                totalDuration.toString(),
-            ])
-        })
-    })
-
-    describe("OnChainOrderStatus Entity", () => {
-        test("Should create OnChainOrderStatus entity with correct fields", () => {
-            let orderHash = Bytes.fromHexString(
-                "0x1111111111111111111111111111111111111111111111111111111111111111"
-            ) //Random order hash
-            let entityId = orderHash.toHexString()
-            let totalFilled = BigInt.fromI32(1000)
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
-
-            let entity = new OnChainOrderStatus(entityId)
-            entity.orderHash = orderHash
-            entity.totalFilled = totalFilled
-            entity.cancelled = false
-            entity.updatedAt = timestamp
-            entity.updatedAtBlock = blockNumber
-            entity.save()
 
             assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
+                ORDER_STATUS,
+                ORDER_ID,
                 "orderHash",
-                orderHash.toHexString()
+                ORDER_HASH.toHexString()
             )
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "totalFilled", "500")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "cancelled", "false")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "isPreSigned", "false")
             assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "totalFilled",
-                totalFilled.toString()
-            )
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "cancelled",
-                "false"
-            )
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
+                ORDER_STATUS,
+                ORDER_ID,
                 "updatedAt",
-                timestamp.toString()
+                DEFAULT_TIMESTAMP.toString()
             )
             assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
+                ORDER_STATUS,
+                ORDER_ID,
                 "updatedAtBlock",
-                blockNumber.toString()
+                DEFAULT_BLOCK.toString()
             )
         })
 
-        test("Should handle cancelled order status", () => {
-            let orderHash = Bytes.fromHexString(
-                "0x1111111111111111111111111111111111111111111111111111111111111111"
-            ) //Random order hash
-            let entityId = orderHash.toHexString()
-            let totalFilled = BigInt.fromI32(500)
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
+        test("accumulates totalFilled across multiple fills", () => {
+            handleOrderFilled(
+                createOrderFilledEvent(ORDER_HASH, BigInt.fromI32(500))
+            )
+            handleOrderFilled(
+                createOrderFilledEvent(ORDER_HASH, BigInt.fromI32(300))
+            )
 
-            let entity = new OnChainOrderStatus(entityId)
-            entity.orderHash = orderHash
-            entity.totalFilled = totalFilled
-            entity.cancelled = true // Order is cancelled
-            entity.updatedAt = timestamp
-            entity.updatedAtBlock = blockNumber
-            entity.save()
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "totalFilled", "800")
+            assert.entityCount(ORDER_STATUS, 1)
+        })
+    })
 
+    describe("handleOrderCanceled", () => {
+        test("marks a fresh order cancelled with zero fill and not pre-signed", () => {
+            handleOrderCanceled(createOrderCanceledEvent(MAKER, ORDER_HASH))
+
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "cancelled", "true")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "totalFilled", "0")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "isPreSigned", "false")
+        })
+
+        test("preserves accumulated fills when cancelling an existing order", () => {
+            handleOrderFilled(
+                createOrderFilledEvent(ORDER_HASH, BigInt.fromI32(100))
+            )
+            handleOrderCanceled(createOrderCanceledEvent(MAKER, ORDER_HASH))
+
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "cancelled", "true")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "totalFilled", "100")
+        })
+    })
+
+    describe("handleOrderPreSigned", () => {
+        test("creates a pre-signed order with zero fill before any fill", () => {
+            handleOrderPreSigned(createOrderPreSignedEvent(ORDER_HASH, MAKER))
+
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "isPreSigned", "true")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "totalFilled", "0")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "cancelled", "false")
             assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
+                ORDER_STATUS,
+                ORDER_ID,
                 "orderHash",
-                orderHash.toHexString()
+                ORDER_HASH.toHexString()
             )
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "totalFilled",
-                totalFilled.toString()
+        })
+
+        test("pre-sign then fill: stays pre-signed and accumulates the fill", () => {
+            handleOrderPreSigned(createOrderPreSignedEvent(ORDER_HASH, MAKER))
+            handleOrderFilled(
+                createOrderFilledEvent(ORDER_HASH, BigInt.fromI32(250))
             )
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "cancelled",
-                "true"
+
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "isPreSigned", "true")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "totalFilled", "250")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "cancelled", "false")
+        })
+
+        test("fill then pre-sign: preserves fills and flips isPreSigned", () => {
+            handleOrderFilled(
+                createOrderFilledEvent(ORDER_HASH, BigInt.fromI32(700))
             )
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "updatedAt",
-                timestamp.toString()
-            )
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "updatedAtBlock",
-                blockNumber.toString()
-            )
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "isPreSigned", "false")
+
+            handleOrderPreSigned(createOrderPreSignedEvent(ORDER_HASH, MAKER))
+
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "isPreSigned", "true")
+            assert.fieldEquals(ORDER_STATUS, ORDER_ID, "totalFilled", "700")
+            assert.entityCount(ORDER_STATUS, 1)
         })
     })
 
-    describe("Performance and Edge Cases", () => {
-        test("Should handle multiple order status entities efficiently", () => {
-            // Test creating multiple order status entities to simulate high volume
-            let baseOrderHash =
-                "0x1111111111111111111111111111111111111111111111111111111111111"
-            let fillAmount = BigInt.fromI32(100)
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
-
-            for (let i = 0; i < 10; i++) {
-                let orderHash = Bytes.fromHexString(
-                    baseOrderHash + i.toString().padStart(3, "0")
+    describe("handleLimitOrderFeeChange", () => {
+        test("creates the fee singleton with previous and new fee", () => {
+            handleLimitOrderFeeChange(
+                createLimitOrderFeeChangeEvent(
+                    BigInt.zero(),
+                    BigInt.fromString("10000000000000000") // 1% in WAD
                 )
-                let entityId = orderHash.toHexString()
+            )
 
-                let entity = new OnChainOrderStatus(entityId)
-                entity.orderHash = orderHash
-                entity.totalFilled = fillAmount
-                entity.cancelled = false
-                entity.updatedAt = timestamp
-                entity.updatedAtBlock = blockNumber
-                entity.save()
-
-                // Verify each entity was created correctly
-                assert.fieldEquals(
-                    "OnChainOrderStatus",
-                    entityId,
-                    "totalFilled",
-                    fillAmount.toString()
-                )
-                assert.fieldEquals(
-                    "OnChainOrderStatus",
-                    entityId,
-                    "cancelled",
-                    "false"
-                )
-            }
+            assert.fieldEquals(LIMIT_ORDER_FEE, FEE_ID, "previousFee", "0")
+            assert.fieldEquals(
+                LIMIT_ORDER_FEE,
+                FEE_ID,
+                "currentFee",
+                "10000000000000000"
+            )
+            assert.entityCount(LIMIT_ORDER_FEE, 1)
         })
 
-        test("Should handle zero fill amounts", () => {
-            let orderHash = Bytes.fromHexString(
-                "0x0000000000000000000000000000000000000000000000000000000000000001"
-            ) //Random order hash
-            let entityId = orderHash.toHexString()
-            let zeroFill = BigInt.fromI32(0)
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
-
-            let entity = new OnChainOrderStatus(entityId)
-            entity.orderHash = orderHash
-            entity.totalFilled = zeroFill
-            entity.cancelled = false
-            entity.updatedAt = timestamp
-            entity.updatedAtBlock = blockNumber
-            entity.save()
+        test("updates the singleton in place on subsequent changes", () => {
+            handleLimitOrderFeeChange(
+                createLimitOrderFeeChangeEvent(
+                    BigInt.zero(),
+                    BigInt.fromString("10000000000000000")
+                )
+            )
+            handleLimitOrderFeeChange(
+                createLimitOrderFeeChangeEvent(
+                    BigInt.fromString("10000000000000000"),
+                    BigInt.fromString("20000000000000000")
+                )
+            )
 
             assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "totalFilled",
-                "0"
+                LIMIT_ORDER_FEE,
+                FEE_ID,
+                "previousFee",
+                "10000000000000000"
             )
             assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "cancelled",
-                "false"
+                LIMIT_ORDER_FEE,
+                FEE_ID,
+                "currentFee",
+                "20000000000000000"
             )
-        })
-
-        test("Should handle large fill amounts", () => {
-            let orderHash = Bytes.fromHexString(
-                "0x9999999999999999999999999999999999999999999999999999999999999999"
-            ) //Random order hash
-            let entityId = orderHash.toHexString()
-            let largeFill = BigInt.fromString("1000000000000000000000") // 1000 tokens with 18 decimals
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
-
-            let entity = new OnChainOrderStatus(entityId)
-            entity.orderHash = orderHash
-            entity.totalFilled = largeFill
-            entity.cancelled = false
-            entity.updatedAt = timestamp
-            entity.updatedAtBlock = blockNumber
-            entity.save()
-
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "totalFilled",
-                largeFill.toString()
-            )
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "cancelled",
-                "false"
-            )
-        })
-
-        test("Should handle accumulative fills simulation", () => {
-            let orderHash = Bytes.fromHexString(
-                "0x0000000000000000000000000000000000000000000000000000000000000001"
-            ) //Random order hash
-            let entityId = orderHash.toHexString()
-            let firstFill = BigInt.fromI32(500)
-            let secondFill = BigInt.fromI32(300)
-            let expectedTotal = firstFill.plus(secondFill)
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
-
-            // Simulate first fill
-            let entity = new OnChainOrderStatus(entityId)
-            entity.orderHash = orderHash
-            entity.totalFilled = firstFill
-            entity.cancelled = false
-            entity.updatedAt = timestamp
-            entity.updatedAtBlock = blockNumber
-            entity.save()
-
-            // Load and update with second fill (simulating handler behavior)
-            let loadedEntity = OnChainOrderStatus.load(entityId)
-            if (loadedEntity != null) {
-                loadedEntity.totalFilled =
-                    loadedEntity.totalFilled.plus(secondFill)
-                loadedEntity.save()
-            }
-
-            // Verify total is accumulated correctly
-            assert.fieldEquals(
-                "OnChainOrderStatus",
-                entityId,
-                "totalFilled",
-                expectedTotal.toString()
-            )
+            assert.entityCount(LIMIT_ORDER_FEE, 1)
         })
     })
 
-    describe("UserNonce Performance Tests", () => {
-        test("Should handle multiple user nonces efficiently", () => {
-            let baseUserAddress = "0x111111111111111111111111111111111111111"
-            let nonce = BigInt.fromI32(5)
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
-
-            for (let i = 0; i < 5; i++) {
-                let userAddress = Address.fromString(
-                    baseUserAddress + i.toString()
+    describe("nonce handlers", () => {
+        test("handleNonceIncreased tracks the latest nonce per user", () => {
+            handleNonceIncreased(
+                createNonceIncreasedEvent(
+                    MAKER,
+                    BigInt.fromI32(5),
+                    BigInt.fromI32(6)
                 )
-                let entityId = "nonce-" + userAddress.toHexString()
-                let userNonce = nonce.plus(BigInt.fromI32(i))
+            )
 
-                let entity = new UserNonce(entityId)
-                entity.user = userAddress
-                entity.latestNonce = userNonce
-                entity.updatedAt = timestamp
-                entity.updatedAtBlock = blockNumber
-                entity.save()
+            const id = "nonce-" + MAKER.toHexString()
+            assert.fieldEquals(USER_NONCE, id, "user", MAKER.toHexString())
+            assert.fieldEquals(USER_NONCE, id, "latestNonce", "6")
 
-                // Verify each nonce entity was created correctly
-                assert.fieldEquals(
-                    "UserNonce",
-                    entityId,
-                    "user",
-                    userAddress.toHexString()
+            handleNonceIncreased(
+                createNonceIncreasedEvent(
+                    MAKER,
+                    BigInt.fromI32(6),
+                    BigInt.fromI32(9)
                 )
-                assert.fieldEquals(
-                    "UserNonce",
-                    entityId,
-                    "latestNonce",
-                    userNonce.toString()
-                )
-            }
+            )
+            assert.fieldEquals(USER_NONCE, id, "latestNonce", "9")
+            assert.entityCount(USER_NONCE, 1)
         })
 
-        test("Should handle nonce updates simulation", () => {
-            let userAddress = Address.fromString(
-                "0x9876543210987654321098765432109876543210"
-            ) //random address
-            let entityId = "nonce-" + userAddress.toHexString()
-            let initialNonce = BigInt.fromI32(5)
-            let updatedNonce = BigInt.fromI32(10)
-            let timestamp = BigInt.fromI32(1234567890)
-            let blockNumber = BigInt.fromI32(12345)
-
-            // Create initial nonce
-            let entity = new UserNonce(entityId)
-            entity.user = userAddress
-            entity.latestNonce = initialNonce
-            entity.updatedAt = timestamp
-            entity.updatedAtBlock = blockNumber
-            entity.save()
-
-            // Load and update nonce (simulating handler behavior)
-            let loadedEntity = UserNonce.load(entityId)
-            if (loadedEntity != null) {
-                loadedEntity.latestNonce = updatedNonce
-                loadedEntity.save()
-            }
-
-            // Verify nonce was updated correctly
-            assert.fieldEquals(
-                "UserNonce",
-                entityId,
-                "latestNonce",
-                updatedNonce.toString()
-            )
-        })
-    })
-
-    describe("🚀 Limit Orders Performance Benchmarks", () => {
-        test("Bulk UserNonce Creation Performance", () => {
-            const timer = new PerformanceTimer(
-                "Bulk UserNonce Creation (100 entities)"
-            )
-            timer.start()
-
-            const entityCount = 100
-            const baseAddress = "0x1000000000000000000000000000000000000"
-
-            log.info("🔥 Starting bulk creation of {} UserNonce entities", [
-                entityCount.toString(),
-            ])
-
-            for (let i = 0; i < entityCount; i++) {
-                timer.incrementOperation()
-
-                let userAddress = Address.fromString(
-                    baseAddress + i.toString().padStart(3, "0")
+        test("handleNonceManagerNonceIncreased updates the same UserNonce entity", () => {
+            handleNonceManagerNonceIncreased(
+                createNonceIncreasedEvent(
+                    MAKER,
+                    BigInt.fromI32(0),
+                    BigInt.fromI32(1)
                 )
-                let entityId = "nonce-" + userAddress.toHexString()
-                let nonce = BigInt.fromI32(i + 1)
-                let timestamp = BigInt.fromI32(1234567890 + i)
-                let blockNumber = BigInt.fromI32(12345 + i)
-
-                let entity = new UserNonce(entityId)
-                entity.user = userAddress
-                entity.latestNonce = nonce
-                entity.updatedAt = timestamp
-                entity.updatedAtBlock = blockNumber
-                entity.save()
-
-                PerformanceMetrics.recordEntityCreation()
-
-                if (i % 25 === 0) {
-                    log.info("📊 Created {} UserNonce entities so far...", [
-                        i.toString(),
-                    ])
-                }
-            }
-
-            const totalOperations = timer.end()
-            log.info(
-                "✅ Bulk UserNonce creation completed: {} entities with {} operations",
-                [entityCount.toString(), totalOperations.toString()]
             )
-            log.info("⚡ Average operations per entity: {}", [
-                (totalOperations / entityCount).toString(),
-            ])
+
+            const id = "nonce-" + MAKER.toHexString()
+            assert.fieldEquals(USER_NONCE, id, "latestNonce", "1")
+            assert.entityCount(USER_NONCE, 1)
         })
 
-        test("Bulk OnChainOrderStatus Creation Performance", () => {
-            const timer = new PerformanceTimer(
-                "Bulk OnChainOrderStatus Creation (100 entities)"
-            )
-            timer.start()
-
-            const entityCount = 100
-            const baseOrderHash =
-                "0x2000000000000000000000000000000000000000000000000000000000000"
-
-            log.info(
-                "🔥 Starting bulk creation of {} OnChainOrderStatus entities",
-                [entityCount.toString()]
+        test("both nonce handlers update the same entity in place", () => {
+            handleNonceIncreased(
+                createNonceIncreasedEvent(
+                    MAKER,
+                    BigInt.fromI32(0),
+                    BigInt.fromI32(5)
+                )
             )
 
-            for (let i = 0; i < entityCount; i++) {
-                timer.incrementOperation()
+            const id = "nonce-" + MAKER.toHexString()
+            assert.fieldEquals(USER_NONCE, id, "latestNonce", "5")
+            assert.entityCount(USER_NONCE, 1)
 
-                let orderHash = Bytes.fromHexString(
-                    baseOrderHash + i.toString().padStart(3, "0")
+            // NonceManager handler must resolve to the same UserNonce id
+            handleNonceManagerNonceIncreased(
+                createNonceIncreasedEvent(
+                    MAKER,
+                    BigInt.fromI32(5),
+                    BigInt.fromI32(8)
                 )
-                let entityId = orderHash.toHexString()
-                let totalFilled = BigInt.fromI32((i + 1) * 100)
-                let timestamp = BigInt.fromI32(1234567890 + i)
-                let blockNumber = BigInt.fromI32(12345 + i)
-
-                let entity = new OnChainOrderStatus(entityId)
-                entity.orderHash = orderHash
-                entity.totalFilled = totalFilled
-                entity.cancelled = i % 10 === 0 // Every 10th order is cancelled
-                entity.updatedAt = timestamp
-                entity.updatedAtBlock = blockNumber
-                entity.save()
-
-                PerformanceMetrics.recordEntityCreation()
-
-                if (i % 25 === 0) {
-                    log.info(
-                        "📊 Created {} OnChainOrderStatus entities so far...",
-                        [i.toString()]
-                    )
-                }
-            }
-
-            const totalOperations = timer.end()
-            log.info(
-                "✅ Bulk OnChainOrderStatus creation completed: {} entities with {} operations",
-                [entityCount.toString(), totalOperations.toString()]
             )
-            log.info("⚡ Average operations per entity: {}", [
-                (totalOperations / entityCount).toString(),
-            ])
-        })
 
-        test("Mixed Operations Performance Test", () => {
-            const timer = new PerformanceTimer(
-                "Mixed Operations Performance Test"
-            )
-            timer.start()
-
-            log.info("🎯 Starting mixed operations performance test", [])
-
-            // Create entities
-            log.info("📈 Starting entity creation phase", [])
-            for (let i = 0; i < 50; i++) {
-                timer.incrementOperation()
-
-                let userAddress = Address.fromString(
-                    "0x3000000000000000000000000000000000000" +
-                        i.toString().padStart(3, "0")
-                )
-                let nonceEntityId = "nonce-" + userAddress.toHexString()
-
-                let nonceEntity = new UserNonce(nonceEntityId)
-                nonceEntity.user = userAddress
-                nonceEntity.latestNonce = BigInt.fromI32(i)
-                nonceEntity.updatedAt = BigInt.fromI32(1234567890)
-                nonceEntity.updatedAtBlock = BigInt.fromI32(12345)
-                nonceEntity.save()
-
-                let orderHash = Bytes.fromHexString(
-                    "0x3000000000000000000000000000000000000000000000000000000000000" +
-                        i.toString().padStart(3, "0")
-                )
-                let orderEntityId = orderHash.toHexString()
-
-                let orderEntity = new OnChainOrderStatus(orderEntityId)
-                orderEntity.orderHash = orderHash
-                orderEntity.totalFilled = BigInt.fromI32(i * 100)
-                orderEntity.cancelled = false
-                orderEntity.updatedAt = BigInt.fromI32(1234567890)
-                orderEntity.updatedAtBlock = BigInt.fromI32(12345)
-                orderEntity.save()
-            }
-            log.info("📈 Entity creation phase completed", [])
-
-            // Query entities
-            log.info("🔍 Starting entity query phase", [])
-            for (let i = 0; i < 50; i++) {
-                timer.incrementOperation()
-
-                let userAddress = Address.fromString(
-                    "0x3000000000000000000000000000000000000" +
-                        i.toString().padStart(3, "0")
-                )
-                let nonceEntityId = "nonce-" + userAddress.toHexString()
-                let loadedNonce = UserNonce.load(nonceEntityId)
-
-                let orderHash = Bytes.fromHexString(
-                    "0x3000000000000000000000000000000000000000000000000000000000000" +
-                        i.toString().padStart(3, "0")
-                )
-                let orderEntityId = orderHash.toHexString()
-                let loadedOrder = OnChainOrderStatus.load(orderEntityId)
-
-                assert.assertTrue(loadedNonce !== null)
-                assert.assertTrue(loadedOrder !== null)
-            }
-            PerformanceMetrics.recordQuery()
-            log.info("🔍 Entity query phase completed", [])
-
-            // Update entities
-            log.info("💾 Starting entity update phase", [])
-            for (let i = 0; i < 50; i++) {
-                timer.incrementOperation()
-
-                let userAddress = Address.fromString(
-                    "0x3000000000000000000000000000000000000" +
-                        i.toString().padStart(3, "0")
-                )
-                let nonceEntityId = "nonce-" + userAddress.toHexString()
-                let loadedNonce = UserNonce.load(nonceEntityId)
-
-                if (loadedNonce !== null) {
-                    loadedNonce.latestNonce = loadedNonce.latestNonce.plus(
-                        BigInt.fromI32(1)
-                    )
-                    loadedNonce.save()
-                }
-
-                let orderHash = Bytes.fromHexString(
-                    "0x3000000000000000000000000000000000000000000000000000000000000" +
-                        i.toString().padStart(3, "0")
-                )
-                let orderEntityId = orderHash.toHexString()
-                let loadedOrder = OnChainOrderStatus.load(orderEntityId)
-
-                if (loadedOrder !== null) {
-                    loadedOrder.totalFilled = loadedOrder.totalFilled.plus(
-                        BigInt.fromI32(50)
-                    )
-                    loadedOrder.save()
-                }
-            }
-            PerformanceMetrics.recordSave()
-            log.info("💾 Entity update phase completed", [])
-
-            const totalOperations = timer.end()
-            log.info(
-                "🏆 Mixed operations test completed with {} total operations",
-                [totalOperations.toString()]
-            )
-            log.info(
-                "📊 Mixed operations performance test finished successfully",
-                []
-            )
-        })
-
-        test("Memory Usage Pattern Analysis", () => {
-            const timer = new PerformanceTimer("Memory Usage Pattern Analysis")
-            timer.start()
-
-            log.info("🧠 Starting memory usage pattern analysis", [])
-
-            // Test with increasing entity sizes
-            const testSizes = [10, 50, 100, 200]
-
-            for (let sizeIndex = 0; sizeIndex < testSizes.length; sizeIndex++) {
-                const size = testSizes[sizeIndex]
-                log.info("📏 Testing with {} entities", [size.toString()])
-
-                // Clear store before each size test
-                clearStore()
-
-                // Create entities of current size
-                for (let i = 0; i < size; i++) {
-                    timer.incrementOperation()
-
-                    let userAddress = Address.fromString(
-                        "0x4000000000000000000000000000000000000" +
-                            i.toString().padStart(3, "0")
-                    )
-                    let entityId = "nonce-" + userAddress.toHexString()
-
-                    let entity = new UserNonce(entityId)
-                    entity.user = userAddress
-                    entity.latestNonce = BigInt.fromI32(i)
-                    entity.updatedAt = BigInt.fromI32(1234567890)
-                    entity.updatedAtBlock = BigInt.fromI32(12345)
-                    entity.save()
-                }
-
-                log.info("⏱️  {} entities created with {} operations", [
-                    size.toString(),
-                    size.toString(),
-                ])
-            }
-
-            const totalOperations = timer.end()
-            log.info(
-                "🧠 Memory usage pattern analysis completed with {} total operations",
-                [totalOperations.toString()]
-            )
+            assert.fieldEquals(USER_NONCE, id, "latestNonce", "8")
+            assert.entityCount(USER_NONCE, 1)
         })
     })
 })

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -135,6 +135,10 @@ dataSources:
           handler: handleOrderFilled
         - event: OrderCanceled(address,bytes32)
           handler: handleOrderCanceled
+        - event: OrderPreSigned(indexed bytes32,indexed address)
+          handler: handleOrderPreSigned
+        - event: LimitOrderFeeChange(uint256,uint256)
+          handler: handleLimitOrderFeeChange
         - event: NonceIncreased(indexed address,uint256,uint256)
           handler: handleNonceIncreased
         - event: AuthorityUpdated(address)


### PR DESCRIPTION
Closes #189.

Indexes the two new LimitOrderEngine events now on the contracts' `main`:

- **OrderPreSigned** → new `isPreSigned: Boolean!` flag on `OnChainOrderStatus` (defaulted `false` on every creation path), handled by `handleOrderPreSigned`. Satisfies issue #189 (SDK reader can tell a pre-signed order exists independent of an off-chain signature).
- **LimitOrderFeeChange** → new `LimitOrderFee` singleton entity + `handleLimitOrderFeeChange` (tracks current/previous protocol fee).

### Details
- ABI regenerated from contracts `main` (12 events); both events registered on the `LimitOrderEngine` data source across all 13 networks.
- Tests **rewritten as real handler tests** (`newMockEvent`) — the old file was coverage theater that never invoked a handler. Covers presign↔fill orderings, fee-singleton upsert, and cross-handler nonce.
- `yarn codegen` / `graph build` / `yarn test`: **green (12/12)**.

### Note
The `limitOrderEngine` address is `0x0` in all network configs until the engine is deployed — set it per network (e.g. `base.json`) when deploying for testing. Pre-existing unrelated test breakage in `tests/mocks` (LP_VAULT/metavault removal fallout on master) is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)