### PR TITLE
ci: validate canonical subgraph build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  subgraph:
+    name: generate and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+
+      - name: Generate canonical manifest
+        run: |
+          yarn gen:config --network mainnet
+          cp subgraph.mainnet.yaml subgraph.yaml
+
+      - name: Generate types
+        run: yarn codegen subgraph.yaml
+
+      - name: Build
+        run: yarn graph build subgraph.yaml

--- a/src/mappings/metavaults/modules.ts
+++ b/src/mappings/metavaults/modules.ts
@@ -6,7 +6,7 @@ import {
     MetavaultTransaction,
 } from "../../../generated/schema"
 import { GnosisSafeModule } from "../../../generated/templates"
-import { EnabledModule, SafeModuleTransaction, SafeMultiSigTransaction } from "../../../generated/templates/GnosisSAFE/GnosisSAFE"
+import { EnabledModule, SafeModuleTransaction, SafeMultiSigTransaction } from "../../../generated/templates/GnosisSafe/GnosisSAFE"
 import { TransactionAdded } from "../../../generated/templates/GnosisSafeModule/GnosisSAFEModule"
 
 


### PR DESCRIPTION
## Summary

- add a local, read-only CI workflow for pull requests and master
- generate the canonical mainnet manifest, generate types, and compile the subgraph
- fix a generated-import directory casing bug exposed by the Linux runner
- pin GitHub Actions and cancel superseded runs; no deployment or secrets

## Scope note

The existing Matchstick suite is not made blocking here: it currently fails to compile on the canonical branch because stale test mocks reference missing constants. The useful green baseline is manifest generation plus a complete Graph build; test repair should be isolated from this CI bootstrap.

## Local verification

- yarn gen:config --network mainnet
- cp subgraph.mainnet.yaml subgraph.yaml
- yarn codegen subgraph.yaml
- yarn graph build subgraph.yaml